### PR TITLE
ci: restore strict CI checks after Black formatting PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
   # Security scanning
   security-scan:
     runs-on: ubuntu-latest
-    # Allow this job to pass even with errors for PR #12 (black formatting PR)
-    continue-on-error: ${{ github.event.pull_request.number == 12 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,8 +50,6 @@ jobs:
   lint-and-test:
     needs: security-scan
     runs-on: ubuntu-latest
-    # Allow this job to pass even with errors for PR #12 (black formatting PR)
-    continue-on-error: ${{ github.event.pull_request.number == 12 }}
     services:
       postgres:
         image: postgres:15
@@ -117,8 +113,6 @@ jobs:
   build-images:
     needs: lint-and-test
     runs-on: ubuntu-latest
-    # Allow this job to pass even with errors for PR #12 (black formatting PR)
-    continue-on-error: ${{ github.event.pull_request.number == 12 }}
     strategy:
       matrix:
         service:
@@ -172,8 +166,6 @@ jobs:
   integration-tests:
     needs: build-images
     runs-on: ubuntu-latest
-    # Allow this job to pass even with errors for PR #12 (black formatting PR)
-    continue-on-error: ${{ github.event.pull_request.number == 12 }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/metrics-ci-pipeline.yml
+++ b/.github/workflows/metrics-ci-pipeline.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     # Skip validation on main to get a green run (temporary)
     if: github.ref != 'refs/heads/main' || github.event_name == 'pull_request'
-    # Allow this job to pass even with errors for PR #12 (black formatting PR)
-    continue-on-error: ${{ github.event.pull_request.number == 12 }}
     steps:
       - uses: actions/checkout@v3
       
@@ -60,8 +58,6 @@ jobs:
   validate-metrics:
     runs-on: ubuntu-latest
     needs: validate
-    # Allow this job to pass even with errors for PR #12 (black formatting PR)
-    continue-on-error: ${{ github.event.pull_request.number == 12 }}
     steps:
       - uses: actions/checkout@v3
       
@@ -158,8 +154,6 @@ jobs:
     needs: validate
     # Skip this job for manual runs via workflow_dispatch
     if: github.event_name != 'workflow_dispatch'
-    # Allow this job to pass even with errors for PR #12 (black formatting PR)
-    continue-on-error: ${{ github.event.pull_request.number == 12 }}
     steps:
       - uses: actions/checkout@v3
 
@@ -180,8 +174,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, validate-metrics]
     if: github.event_name == 'pull_request'
-    # Allow this job to pass even with errors for PR #12 (black formatting PR)
-    continue-on-error: ${{ github.event.pull_request.number == 12 }}
     steps:
       - uses: actions/checkout@v3
       

--- a/.github/workflows/metrics-guard.yml
+++ b/.github/workflows/metrics-guard.yml
@@ -10,8 +10,6 @@ on:
 jobs:
   validate-metrics:
     runs-on: ubuntu-latest
-    # Allow this job to pass even with errors for PR #12 (black formatting PR)
-    continue-on-error: ${{ github.event.pull_request.number == 12 }}
     steps:
       - uses: actions/checkout@v3
       


### PR DESCRIPTION
This PR removes the temporary CI bypass settings that were added to allow the Black formatting PR (#12) to pass CI checks. Now that the formatting has been applied across the codebase, these bypass settings are no longer needed and strict CI checking should be restored.