### PR TITLE
chore: add pre-commit configuration with isort, black, and flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-yaml
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-case-conflict
+      - id: check-merge-conflict
+
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-docstrings, flake8-quotes]
+        exclude: "^(tests/|docs/|migrations/)"


### PR DESCRIPTION
This PR adds a pre-commit configuration that includes:

- isort for import sorting
- black for code formatting
- flake8 for linting
- basic pre-commit hooks for file quality

This will help ensure consistent code quality across the repository and make it easier for developers to maintain proper formatting before pushing their changes.

Note: Configuration for isort and black was already in pyproject.toml, and both tools were already in requirements-dev.txt. This PR just adds pre-commit hooks to make the tools easier to use.