### PR TITLE
fix: add mypy exclusions for duplicate modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,8 @@ jobs:
       - name: Run linters
         run: |
           flake8 .
-          mypy .
+          # Use wrapper script to properly exclude problematic directories
+          ./scripts/run-mypy.sh .
           bandit -r agents/ libs/ services/ -c pyproject.toml
 
       - name: Run tests with coverage

--- a/.github/workflows/metrics-ci-pipeline.yml
+++ b/.github/workflows/metrics-ci-pipeline.yml
@@ -49,7 +49,8 @@ jobs:
           # Run mypy and pytest for full validation
           if [[ "$GITHUB_REF" != "refs/heads/main" && "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
             echo "Running full validation with mypy and pytest"
-            mypy .
+            # Use our wrapper script to properly exclude problematic directories
+            ./scripts/run-mypy.sh .
             pytest -xvs
           else
             echo "SKIPPING mypy type checking for main branch"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-yaml
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-case-conflict
+      - id: check-merge-conflict
+
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-docstrings, flake8-quotes]
+        exclude: "^(tests/|docs/|migrations/)"

--- a/agents/financial_tax/__init__.py
+++ b/agents/financial_tax/__init__.py
@@ -2,19 +2,19 @@
 
 from .agent import FinancialTaxAgent
 from .chains import (
-    TaxCalculationChain,
-    FinancialAnalysisChain,
     ComplianceCheckChain,
+    FinancialAnalysisChain,
     RateLookupChain,
+    TaxCalculationChain,
 )
 from .models import (
-    TaxCalculationRequest,
-    FinancialAnalysisRequest,
     ComplianceCheckRequest,
-    TaxRateRequest,
-    TaxCalculationResponse,
-    FinancialAnalysisResponse,
     ComplianceCheckResponse,
+    FinancialAnalysisRequest,
+    FinancialAnalysisResponse,
+    TaxCalculationRequest,
+    TaxCalculationResponse,
+    TaxRateRequest,
     TaxRateResponse,
 )
 

--- a/agents/financial_tax/agent.py
+++ b/agents/financial_tax/agent.py
@@ -1,22 +1,24 @@
 """Financial Tax Agent implementation"""
 
-from typing import Dict, Any, List
+from typing import Any, Dict, List
+
 import structlog
 from langchain_openai import ChatOpenAI
-from langgraph.graph import Graph, END
+from langgraph.graph import END, Graph
 
-from libs.agent_core import BaseAgent
 from libs.a2a_adapter import A2AEnvelope
+from libs.agent_core import BaseAgent
+
 from .chains import (
-    TaxCalculationChain,
-    FinancialAnalysisChain,
     ComplianceCheckChain,
+    FinancialAnalysisChain,
     RateLookupChain,
+    TaxCalculationChain,
 )
 from .models import (
-    TaxCalculationRequest,
-    FinancialAnalysisRequest,
     ComplianceCheckRequest,
+    FinancialAnalysisRequest,
+    TaxCalculationRequest,
     TaxRateRequest,
 )
 

--- a/agents/financial_tax/chains.py
+++ b/agents/financial_tax/chains.py
@@ -1,17 +1,19 @@
 """LangChain implementations for Financial Tax Agent"""
 
-from typing import Dict, Any, List
+from typing import Any, Dict, List
+
 from langchain.chains import LLMChain
+from langchain.output_parsers import PydanticOutputParser
 from langchain.prompts import PromptTemplate
 from langchain_openai import ChatOpenAI
-from langchain.output_parsers import PydanticOutputParser
+
 from .models import (
-    TaxCalculationRequest,
-    TaxCalculationResponse,
-    FinancialAnalysisRequest,
-    FinancialAnalysisResponse,
     ComplianceCheckRequest,
     ComplianceCheckResponse,
+    FinancialAnalysisRequest,
+    FinancialAnalysisResponse,
+    TaxCalculationRequest,
+    TaxCalculationResponse,
     TaxRateRequest,
     TaxRateResponse,
 )

--- a/agents/financial_tax/models.py
+++ b/agents/financial_tax/models.py
@@ -1,9 +1,10 @@
 """Data models for Financial Tax Agent"""
 
 from datetime import date
-from typing import Dict, List, Optional, Any
-from langchain.pydantic_v1 import BaseModel, Field
 from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from langchain.pydantic_v1 import BaseModel, Field
 
 
 class TaxJurisdiction(str, Enum):

--- a/agents/financial_tax/test_models.py
+++ b/agents/financial_tax/test_models.py
@@ -1,9 +1,10 @@
 """Test models for Financial Tax Agent"""
 
-from typing import Dict, List, Optional, Any
-from langchain.pydantic_v1 import BaseModel, Field, validator
-from enum import Enum
 from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from langchain.pydantic_v1 import BaseModel, Field, validator
 
 
 class FilingStatus(str, Enum):

--- a/agents/financial_tax/tests/test_agent.py
+++ b/agents/financial_tax/tests/test_agent.py
@@ -1,17 +1,18 @@
 """Unit tests for Financial Tax Agent"""
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from agents.financial_tax import FinancialTaxAgent
 from agents.financial_tax.models import (
-    TaxCalculationRequest,
-    FinancialAnalysisRequest,
     ComplianceCheckRequest,
-    TaxRateRequest,
-    TaxJurisdiction,
     EntityType,
+    FinancialAnalysisRequest,
+    TaxCalculationRequest,
+    TaxJurisdiction,
+    TaxRateRequest,
 )
 from libs.a2a_adapter import A2AEnvelope
 

--- a/agents/financial_tax/tests/test_chains.py
+++ b/agents/financial_tax/tests/test_chains.py
@@ -1,21 +1,22 @@
 """Unit tests for Financial Tax Agent chains"""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from agents.financial_tax.chains import (
-    TaxCalculationChain,
-    FinancialAnalysisChain,
     ComplianceCheckChain,
+    FinancialAnalysisChain,
     RateLookupChain,
+    TaxCalculationChain,
 )
 from agents.financial_tax.models import (
-    TaxCalculationRequest,
-    FinancialAnalysisRequest,
     ComplianceCheckRequest,
-    TaxRateRequest,
-    TaxJurisdiction,
     EntityType,
+    FinancialAnalysisRequest,
+    TaxCalculationRequest,
+    TaxJurisdiction,
+    TaxRateRequest,
 )
 
 

--- a/agents/financial_tax/tests/test_models.py
+++ b/agents/financial_tax/tests/test_models.py
@@ -4,16 +4,16 @@ import pytest
 from pydantic import ValidationError
 
 from agents.financial_tax.models import (
-    TaxCalculationRequest,
-    TaxCalculationResponse,
-    FinancialAnalysisRequest,
-    FinancialAnalysisResponse,
     ComplianceCheckRequest,
     ComplianceCheckResponse,
+    EntityType,
+    FinancialAnalysisRequest,
+    FinancialAnalysisResponse,
+    TaxCalculationRequest,
+    TaxCalculationResponse,
+    TaxJurisdiction,
     TaxRateRequest,
     TaxRateResponse,
-    TaxJurisdiction,
-    EntityType,
 )
 
 

--- a/agents/legal_compliance/__init__.py
+++ b/agents/legal_compliance/__init__.py
@@ -1,13 +1,13 @@
 from .agent import LegalComplianceAgent
 from .models import (
     ComplianceAuditRequest,
-    DocumentAnalysisRequest,
-    RegulationCheckRequest,
-    ContractReviewRequest,
     ComplianceAuditResult,
-    DocumentAnalysisResult,
-    RegulationCheckResult,
+    ContractReviewRequest,
     ContractReviewResult,
+    DocumentAnalysisRequest,
+    DocumentAnalysisResult,
+    RegulationCheckRequest,
+    RegulationCheckResult,
 )
 
 __all__ = [

--- a/agents/legal_compliance/agent.py
+++ b/agents/legal_compliance/agent.py
@@ -2,19 +2,20 @@
 
 import os
 from datetime import datetime
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
+
 import structlog
 
+from libs.a2a_adapter import A2AEnvelope, PolicyMiddleware, PubSubTransport, SupabaseTransport
 from libs.agent_core.base_agent import BaseAgent
-from libs.a2a_adapter import A2AEnvelope, PubSubTransport, SupabaseTransport, PolicyMiddleware
 
-from .chains import audit_chain, document_chain, regulation_chain, contract_chain
+from .chains import audit_chain, contract_chain, document_chain, regulation_chain
 from .models import (
     ComplianceAuditRequest,
+    ContractReviewRequest,
     DocumentAnalysisRequest,
     RegulationCheckRequest,
-    ContractReviewRequest,
 )
 
 logger = structlog.get_logger(__name__)

--- a/agents/legal_compliance/chains.py
+++ b/agents/legal_compliance/chains.py
@@ -1,17 +1,18 @@
 """Legal Compliance Chain Components"""
 
+import os
+from typing import Any, Dict
+
 from langchain.chains import LLMChain
+from langchain.output_parsers import PydanticOutputParser
 from langchain.prompts import PromptTemplate
 from langchain_openai import ChatOpenAI
-from langchain.output_parsers import PydanticOutputParser
-from typing import Dict, Any
-import os
 
 from .models import (
     ComplianceAuditResult,
+    ContractReviewResult,
     DocumentAnalysisResult,
     RegulationCheckResult,
-    ContractReviewResult,
 )
 
 # Initialize the LLM

--- a/agents/legal_compliance/models.py
+++ b/agents/legal_compliance/models.py
@@ -1,8 +1,8 @@
 """Legal Compliance Agent Models"""
 
-from typing import Dict, List, Optional, Any
 from datetime import datetime
 from enum import Enum
+from typing import Any, Dict, List, Optional
 
 # Use LangChain's Pydantic v1 for compatibility
 from langchain.pydantic_v1 import BaseModel, Field

--- a/agents/social_intel/adapters/__init__.py
+++ b/agents/social_intel/adapters/__init__.py
@@ -1,5 +1,5 @@
 """Adapters for SocialIntelligence Agent."""
 
-from .a2a_adapter import YouTubeNicheScoutAdapter, YouTubeBlueprintAdapter, map_intent_to_adapter
+from .a2a_adapter import YouTubeBlueprintAdapter, YouTubeNicheScoutAdapter, map_intent_to_adapter
 
 __all__ = ["YouTubeNicheScoutAdapter", "YouTubeBlueprintAdapter", "map_intent_to_adapter"]

--- a/agents/social_intel/adapters/a2a_adapter.py
+++ b/agents/social_intel/adapters/a2a_adapter.py
@@ -1,8 +1,8 @@
 """A2A adapters for SocialIntelligence Agent."""
 
 import json
-from typing import Dict, Any, List, Optional
 from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 
 class YouTubeNicheScoutAdapter:

--- a/agents/social_intel/agent.py
+++ b/agents/social_intel/agent.py
@@ -1,8 +1,9 @@
 """Stub implementation of Social Intelligence Agent."""
 
-from typing import Dict, Any, List
-import structlog
 import asyncio
+from typing import Any, Dict, List
+
+import structlog
 
 logger = structlog.get_logger(__name__)
 

--- a/agents/social_intel/flows/__init__.py
+++ b/agents/social_intel/flows/__init__.py
@@ -1,5 +1,5 @@
 """Prefect flows for YouTube workflows."""
 
-from .youtube_flows import youtube_niche_scout_flow, youtube_blueprint_flow
+from .youtube_flows import youtube_blueprint_flow, youtube_niche_scout_flow
 
 __all__ = ["youtube_niche_scout_flow", "youtube_blueprint_flow"]

--- a/agents/social_intel/flows/youtube_flows.py
+++ b/agents/social_intel/flows/youtube_flows.py
@@ -1,35 +1,35 @@
 """Prefect flows for YouTube workflows in SocialIntelligence Agent."""
 
-import os
-import json
 import asyncio
-import pandas as pd
-import numpy as np
-from datetime import datetime
-import structlog
+import json
+import os
 import uuid
 import zipfile
-from typing import List, Dict, Any, Optional
+from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
-from prefect import flow, task, get_run_logger
-from prefect.utilities.asyncutils import sync_compatible
 import duckdb
-import umap
+import numpy as np
+import pandas as pd
 import sklearn.cluster as skc
+import structlog
+import umap
+from prefect import flow, get_run_logger, task
+from prefect.utilities.asyncutils import sync_compatible
 from sentence_transformers import SentenceTransformer
 
 from ..models.youtube_api import YouTubeAPI
-from ..models.youtube_vectors import YouTubeVectorStorage
 from ..models.youtube_models import (
-    YouTubeNiche,
-    YouTubeVideo,
+    BlueprintResult,
+    NicheScoutResult,
+    YouTubeBlueprint,
     YouTubeChannel,
     YouTubeGap,
-    YouTubeBlueprint,
-    NicheScoutResult,
-    BlueprintResult,
+    YouTubeNiche,
+    YouTubeVideo,
 )
+from ..models.youtube_vectors import YouTubeVectorStorage
 
 logger = structlog.get_logger(__name__)
 

--- a/cleanup-temp/backup-20250513-093609/atlas_memory_resources/code/base_agent.py
+++ b/cleanup-temp/backup-20250513-093609/atlas_memory_resources/code/base_agent.py
@@ -1,11 +1,12 @@
-from abc import ABC, abstractmethod
-from typing import Dict, Any, List, Optional
 import asyncio
-import structlog
 import json
+from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import Any, Dict, List, Optional
 
-from libs.a2a_adapter import A2AEnvelope, PubSubTransport, SupabaseTransport, PolicyMiddleware
+import structlog
+
+from libs.a2a_adapter import A2AEnvelope, PolicyMiddleware, PubSubTransport, SupabaseTransport
 
 logger = structlog.get_logger(__name__)
 

--- a/cleanup-temp/backup-20250513-093609/atlas_memory_resources/code/streamlit_chat_ui.py
+++ b/cleanup-temp/backup-20250513-093609/atlas_memory_resources/code/streamlit_chat_ui.py
@@ -1,11 +1,12 @@
-import streamlit as st
-import requests
-import json
-import time
-import os
-from datetime import datetime
-import structlog
 import asyncio
+import json
+import os
+import time
+from datetime import datetime
+
+import requests
+import streamlit as st
+import structlog
 
 # Configure logging
 logger = structlog.get_logger(__name__)
@@ -195,6 +196,7 @@ async def send_message_async(message: str) -> str:
         ):
             # Import the client lazily to avoid circular imports
             import asyncio
+
             from send_message import create_model_router_client
 
             # Create client if needed

--- a/cleanup-temp/backup-20250513-093609/scripts/tests/integration_test.py
+++ b/cleanup-temp/backup-20250513-093609/scripts/tests/integration_test.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Integration test for YouTube workflows in SocialIntelligence Agent."""
 
-import os
-import json
-import uuid
-import sys
 import asyncio
+import json
+import os
+import sys
+import uuid
 from datetime import datetime
 
 

--- a/cleanup-temp/backup-20250513-093609/scripts/tests/standalone_test.py
+++ b/cleanup-temp/backup-20250513-093609/scripts/tests/standalone_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Standalone test script for YouTube workflows."""
 
-import os
 import json
+import os
 import sys
 from datetime import datetime
 

--- a/cleanup-temp/backup-20250513-093609/scripts/tests/test-model-router-direct.py
+++ b/cleanup-temp/backup-20250513-093609/scripts/tests/test-model-router-direct.py
@@ -3,10 +3,11 @@
 Test script for directly calling the Model Router with a specific numeric model ID.
 """
 
-import requests
 import json
-import time
 import sys
+import time
+
+import requests
 
 
 def get_models():

--- a/cleanup-temp/backup-20250513-093609/scripts/tests/test-openai.py
+++ b/cleanup-temp/backup-20250513-093609/scripts/tests/test-openai.py
@@ -3,10 +3,11 @@
 Simple script to test OpenAI API access using the key from .env.llm
 """
 
-import os
-import requests
 import json
+import os
 import re
+
+import requests
 
 
 def load_env():

--- a/cleanup-temp/backup-20250513-093609/scripts/utils/joke.py
+++ b/cleanup-temp/backup-20250513-093609/scripts/utils/joke.py
@@ -3,9 +3,10 @@
 Simple script to request a joke from Ollama.
 """
 
-import requests
 import json
 import sys
+
+import requests
 
 
 def get_joke(model="tinyllama"):

--- a/cleanup-temp/backup-20250513-093609/scripts/utils/llm/direct-chat.py
+++ b/cleanup-temp/backup-20250513-093609/scripts/utils/llm/direct-chat.py
@@ -11,9 +11,10 @@ Usage:
 If model_name is not provided, defaults to "tinyllama".
 """
 
-import requests
 import json
 import sys
+
+import requests
 
 
 class OllamaChat:

--- a/cleanup-temp/backup-20250513-093609/services/alfred-core/health_patch.py
+++ b/cleanup-temp/backup-20250513-093609/services/alfred-core/health_patch.py
@@ -6,9 +6,10 @@ This patch adds:
 2. Enhances the /health endpoint with detailed status
 """
 
+import logging
+
 from fastapi import FastAPI, Response
 from pydantic import BaseModel
-import logging
 
 # Sample metrics response for Prometheus
 METRICS_TEMPLATE = """

--- a/cleanup-temp/backup-20250513-093609/services/rag-service/health_patch.py
+++ b/cleanup-temp/backup-20250513-093609/services/rag-service/health_patch.py
@@ -6,9 +6,10 @@ This patch adds:
 2. Enhances the /health endpoint with detailed status
 """
 
+import logging
+
 from fastapi import FastAPI, Response
 from pydantic import BaseModel
-import logging
 
 # Sample metrics response for Prometheus
 METRICS_TEMPLATE = """

--- a/cleanup-temp/backup-20250513-093609/tests/integration/integration_test.py
+++ b/cleanup-temp/backup-20250513-093609/tests/integration/integration_test.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Integration test for YouTube workflows in SocialIntelligence Agent."""
 
-import os
-import json
-import uuid
-import sys
 import asyncio
+import json
+import os
+import sys
+import uuid
 from datetime import datetime
 
 

--- a/cleanup-temp/backup-20250513-093609/tests/integration/manual-niche-scout.py
+++ b/cleanup-temp/backup-20250513-093609/tests/integration/manual-niche-scout.py
@@ -6,11 +6,11 @@ This script directly uses the YouTube API to perform a niche analysis for YouTub
 It bypasses the usual platform services and provides a direct way to analyze trends.
 """
 
-import os
-import json
 import argparse
-import time
 import asyncio
+import json
+import os
+import time
 from datetime import datetime, timedelta
 
 # Check if we have the required libraries
@@ -196,8 +196,8 @@ def build_youtube_client():
 
 def parse_duration(duration_str):
     """Parse ISO 8601 duration string to seconds."""
-    import re
     import datetime
+    import re
 
     # Parse the duration string
     pattern = r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?"

--- a/docs/archive/root-cleanup-20250513/integration_test.py
+++ b/docs/archive/root-cleanup-20250513/integration_test.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Integration test for YouTube workflows in SocialIntelligence Agent."""
 
-import os
-import json
-import uuid
-import sys
 import asyncio
+import json
+import os
+import sys
+import uuid
 from datetime import datetime
 
 

--- a/docs/archive/root-cleanup-20250513/manual-niche-scout.py
+++ b/docs/archive/root-cleanup-20250513/manual-niche-scout.py
@@ -6,11 +6,11 @@ This script directly uses the YouTube API to perform a niche analysis for YouTub
 It bypasses the usual platform services and provides a direct way to analyze trends.
 """
 
-import os
-import json
 import argparse
-import time
 import asyncio
+import json
+import os
+import time
 from datetime import datetime, timedelta
 
 # Check if we have the required libraries
@@ -196,8 +196,8 @@ def build_youtube_client():
 
 def parse_duration(duration_str):
     """Parse ISO 8601 duration string to seconds."""
-    import re
     import datetime
+    import re
 
     # Parse the duration string
     pattern = r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?"

--- a/docs/archive/root-cleanup-20250513/standalone_test.py
+++ b/docs/archive/root-cleanup-20250513/standalone_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Standalone test script for YouTube workflows."""
 
-import os
 import json
+import os
 import sys
 from datetime import datetime
 

--- a/docs/code-style-guide.md
+++ b/docs/code-style-guide.md
@@ -1,0 +1,132 @@
+# Code Style Guide
+
+This document provides guidelines and instructions for maintaining consistent code style across the Alfred Agent Platform v2 codebase.
+
+## Python Style Standards
+
+The codebase follows these style guidelines:
+
+- **Black** for code formatting with line length set to 100 characters
+- **isort** for import sorting with Black-compatible settings
+- **flake8** for linting
+- **mypy** for type checking
+
+## How to Format Your Code
+
+### Option 1: Using the Format Script (Recommended)
+
+The project includes a format script that will apply both isort and Black formatting:
+
+```bash
+# Format the entire codebase
+./scripts/format.sh
+
+# Format a specific file or directory
+./scripts/format.sh path/to/file.py
+./scripts/format.sh path/to/directory
+```
+
+### Option 2: Using Pre-commit Hooks
+
+The project includes pre-commit hooks that automatically check formatting on commit:
+
+1. Install pre-commit hooks:
+   ```bash
+   pip install pre-commit
+   pre-commit install
+   ```
+
+2. The hooks will run automatically on each commit
+3. If a hook fails, it will show the issue and prevent the commit
+4. Fix the issues and try committing again
+
+### Option 3: Manual Formatting
+
+You can also run the formatting tools manually:
+
+```bash
+# Sort imports
+isort .
+
+# Format code
+black .
+```
+
+## CI/CD Integration
+
+The CI pipeline includes style checks that will fail if code is not properly formatted. Always format your code before pushing to avoid CI failures.
+
+## Style Configuration
+
+Style configuration is defined in the following files:
+
+- **pyproject.toml**: Contains configurations for Black, isort, and mypy
+- **.pre-commit-config.yaml**: Contains pre-commit hook configurations
+
+## Import Order Guidelines
+
+Imports should be sorted in the following order (handled automatically by isort):
+
+1. Python standard library imports
+2. Third-party library imports
+3. Local application imports
+4. Relative imports
+
+For example:
+
+```python
+# Standard library
+import os
+from datetime import datetime
+from typing import Dict, List
+
+# Third-party libraries
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel
+
+# Local imports
+from libs.agent_core import BaseAgent
+from libs.a2a_adapter import A2AEnvelope
+
+# Relative imports
+from .models import MyModel
+from .utils import helper_function
+```
+
+## Type Hints
+
+Always use type hints for function parameters and return values:
+
+```python
+def process_data(input_data: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Process the input data and return results."""
+    result: Dict[str, Any] = {}
+    # ... processing logic
+    return result
+```
+
+## Comments and Docstrings
+
+- Use docstrings for all public classes and functions
+- Follow Google-style docstring format
+- Include parameter types, return types, and explanations
+
+Example:
+
+```python
+def calculate_metrics(data: pd.DataFrame, threshold: float = 0.5) -> Dict[str, float]:
+    """Calculate performance metrics for the given data.
+    
+    Args:
+        data: DataFrame containing the input data with columns 'prediction' and 'actual'
+        threshold: Decision threshold for binary classification
+        
+    Returns:
+        Dictionary containing metrics (accuracy, precision, recall, f1)
+        
+    Raises:
+        ValueError: If data is empty or required columns are missing
+    """
+    # Implementation
+```

--- a/docs/tools/doc_migration_inventory.py
+++ b/docs/tools/doc_migration_inventory.py
@@ -10,19 +10,19 @@ This script helps with the documentation migration process by:
 5. Creating a CSV or JSON report with migration recommendations
 """
 
-import os
-import sys
-import json
+import argparse
 import csv
-import re
-import time
 import hashlib
-from pathlib import Path
+import json
+import logging
+import os
+import re
+import sys
+import time
+from collections import defaultdict
 from datetime import datetime
 from difflib import SequenceMatcher
-import argparse
-from collections import defaultdict
-import logging
+from pathlib import Path
 
 # Set up logging
 logging.basicConfig(

--- a/docs/tools/doc_validator.py
+++ b/docs/tools/doc_validator.py
@@ -41,17 +41,17 @@ Examples:
     python doc_validator.py --fix-metadata --dry-run /path/to/docs
 """
 
-import os
-import re
-import sys
 import argparse
 import logging
+import os
+import re
 import shutil
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Set, Tuple, Optional, Any
-from dataclasses import dataclass
-from collections import defaultdict
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Configure logging
 logging.basicConfig(

--- a/docs/tools/migrate_document.py
+++ b/docs/tools/migrate_document.py
@@ -35,19 +35,19 @@ Examples:
     python migrate_document.py old_docs/guide.md new_docs/guides/guide.md --check-duplicates
 """
 
-import os
-import sys
-import re
 import argparse
-import shutil
-import json
-from pathlib import Path
-from datetime import datetime
 import difflib
-import hashlib
 import getpass
+import hashlib
+import json
 import logging
-from typing import Dict, List, Set, Tuple, Optional, Any, Union
+import os
+import re
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 # Configure logging
 logging.basicConfig(

--- a/docs/tools/update_metadata.py
+++ b/docs/tools/update_metadata.py
@@ -19,15 +19,14 @@ Options:
     --quiet               Suppress console output
 """
 
+import argparse
+import datetime
+import logging
 import os
 import re
 import sys
-import argparse
-import datetime
 from pathlib import Path
-import logging
-from typing import Dict, List, Tuple, Optional, Set
-
+from typing import Dict, List, Optional, Set, Tuple
 
 # Set up logging
 logging.basicConfig(

--- a/integration_test.py
+++ b/integration_test.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Integration test for YouTube workflows in SocialIntelligence Agent."""
 
-import os
-import json
-import uuid
-import sys
 import asyncio
+import json
+import os
+import sys
+import uuid
 from datetime import datetime
 
 

--- a/libs/a2a_adapter/__init__.py
+++ b/libs/a2a_adapter/__init__.py
@@ -1,7 +1,7 @@
 """Stub implementation of A2A Adapter package."""
 
-from .transport import PubSubTransport, SupabaseTransport
-from .middleware import PolicyMiddleware
 from .envelope import A2AEnvelope
+from .middleware import PolicyMiddleware
+from .transport import PubSubTransport, SupabaseTransport
 
 __all__ = ["PubSubTransport", "SupabaseTransport", "PolicyMiddleware", "A2AEnvelope"]

--- a/libs/a2a_adapter/envelope.py
+++ b/libs/a2a_adapter/envelope.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from typing import Dict, Any, Optional, List
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
+
 from pydantic import BaseModel, Field
 
 

--- a/libs/a2a_adapter/middleware.py
+++ b/libs/a2a_adapter/middleware.py
@@ -1,6 +1,7 @@
 """Stub implementation of middleware for A2A Adapter."""
 
-from typing import Dict, Any, Optional, Callable, List
+from typing import Any, Callable, Dict, List, Optional
+
 import redis
 import structlog
 

--- a/libs/a2a_adapter/transport.py
+++ b/libs/a2a_adapter/transport.py
@@ -1,8 +1,9 @@
 """Stub transport implementation for A2A Adapter."""
 
-from typing import List, Dict, Any, Optional, Callable, Awaitable
 import asyncio
 import json
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
 import structlog
 
 logger = structlog.get_logger(__name__)

--- a/libs/agent_core/__init__.py
+++ b/libs/agent_core/__init__.py
@@ -1,6 +1,6 @@
 """Stub implementation of agent_core package."""
 
-from .health import create_health_app
 from .base_agent import BaseAgent
+from .health import create_health_app
 
 __all__ = ["create_health_app", "BaseAgent"]

--- a/libs/agent_core/base_agent.py
+++ b/libs/agent_core/base_agent.py
@@ -1,11 +1,12 @@
-from abc import ABC, abstractmethod
-from typing import Dict, Any, List, Optional
 import asyncio
-import structlog
 import json
+from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import Any, Dict, List, Optional
 
-from libs.a2a_adapter import A2AEnvelope, PubSubTransport, SupabaseTransport, PolicyMiddleware
+import structlog
+
+from libs.a2a_adapter import A2AEnvelope, PolicyMiddleware, PubSubTransport, SupabaseTransport
 
 logger = structlog.get_logger(__name__)
 

--- a/libs/agent_core/health.py
+++ b/libs/agent_core/health.py
@@ -1,8 +1,8 @@
 """Stub implementation of health module for agent_core."""
 
-from fastapi import FastAPI
 import prometheus_client
 import structlog
+from fastapi import FastAPI
 
 logger = structlog.get_logger(__name__)
 

--- a/libs/observability/logging.py
+++ b/libs/observability/logging.py
@@ -1,7 +1,8 @@
-import structlog
 import logging
 import sys
 from typing import Any, Dict
+
+import structlog
 
 
 def setup_logging(service_name: str, log_level: str = "INFO") -> None:

--- a/libs/observability/metrics.py
+++ b/libs/observability/metrics.py
@@ -1,8 +1,9 @@
-from prometheus_client import Counter, Histogram, Gauge, Summary
 import time
-from typing import Callable, Any
 from functools import wraps
+from typing import Any, Callable
+
 import structlog
+from prometheus_client import Counter, Gauge, Histogram, Summary
 
 logger = structlog.get_logger(__name__)
 

--- a/libs/observability/tracing.py
+++ b/libs/observability/tracing.py
@@ -1,13 +1,14 @@
 import os
-from typing import Optional, Dict, Any
+from functools import wraps
+from typing import Any, Dict, Optional
+
+import structlog
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import Resource, SERVICE_NAME, SERVICE_VERSION
+from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import Status, StatusCode
-from functools import wraps
-import structlog
 
 logger = structlog.get_logger(__name__)
 

--- a/manual-niche-scout.py
+++ b/manual-niche-scout.py
@@ -6,11 +6,11 @@ This script directly uses the YouTube API to perform a niche analysis for YouTub
 It bypasses the usual platform services and provides a direct way to analyze trends.
 """
 
-import os
-import json
 import argparse
-import time
 import asyncio
+import json
+import os
+import time
 from datetime import datetime, timedelta
 
 # Check if we have the required libraries
@@ -196,8 +196,8 @@ def build_youtube_client():
 
 def parse_duration(duration_str):
     """Parse ISO 8601 duration string to seconds."""
-    import re
     import datetime
+    import re
 
     # Parse the duration string
     pattern = r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?"

--- a/mission-control/src/streamlit_app.py
+++ b/mission-control/src/streamlit_app.py
@@ -1,7 +1,8 @@
-import streamlit as st
-import requests
 import json
 import os
+
+import requests
+import streamlit as st
 
 st.set_page_config(
     page_title="Alfred Agent Platform",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,11 @@ python_version = "3.11"
 disallow_untyped_defs = true
 ignore_missing_imports = true
 show_error_codes = true
+exclude = [
+    "cleanup-temp/.*", 
+    "node_modules/.*",
+    "docs/archive/.*"
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/rag-gateway/src/app.py
+++ b/rag-gateway/src/app.py
@@ -1,6 +1,7 @@
-import os
 import logging
-from flask import Flask, request, jsonify
+import os
+
+from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)

--- a/run-black-format.py
+++ b/run-black-format.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
+import os
 import subprocess
 import sys
-import os
 
 
 def main():

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Applies code formatting to the project using isort and black
+# Usage: ./scripts/format.sh [path]
+#   If path is not provided, formats the entire project
+#   If path is provided, formats only the specified path
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Check for Python virtual environment
+if [[ -z "${VIRTUAL_ENV}" && -z "${CONDA_PREFIX}" ]]; then
+  echo "Warning: No active Python virtual environment detected"
+  echo "It's recommended to run this script inside a virtual environment"
+  echo "Continuing anyway..."
+  echo ""
+fi
+
+# Check for black and isort
+if ! command -v black &> /dev/null || ! command -v isort &> /dev/null; then
+  echo "Error: black and/or isort not found in PATH"
+  echo "Please install required dependencies:"
+  echo "  pip install -r requirements-dev.txt"
+  exit 1
+fi
+
+cd "$PROJECT_ROOT"
+
+# Use provided path or default to current directory
+TARGET_PATH="${1:-.}"
+
+echo "🔍 Checking Black version..."
+black --version
+
+echo "🔍 Checking isort version..."
+isort --version
+
+echo ""
+echo "🔄 Running isort..."
+isort --profile black "$TARGET_PATH"
+
+echo ""
+echo "🔄 Running Black..."
+black "$TARGET_PATH"
+
+echo ""
+echo "✅ Formatting complete!"
+echo ""
+echo "👉 Don't forget to run the checks before committing:"
+echo "    make lint"
+echo "    make test"

--- a/scripts/run-mypy.sh
+++ b/scripts/run-mypy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Run mypy with proper exclusions to avoid duplicate module errors
+# This script is intended to be used in CI pipelines
+
+set -eo pipefail
+
+# Exclude problematic directories and files that aren't part of the core codebase
+# but are included in the repo (backups, archives, etc.)
+EXCLUDE_PATTERNS=(
+  "cleanup-temp"
+  "docs/archive"
+  "node_modules"
+)
+
+EXCLUDE_ARGS=""
+for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+  EXCLUDE_ARGS="${EXCLUDE_ARGS} --exclude ${pattern}"
+done
+
+# Run mypy with the exclusions
+echo "Running mypy with exclusions: ${EXCLUDE_ARGS}"
+mypy ${EXCLUDE_ARGS} "$@"

--- a/scripts/test_api_workflow.py
+++ b/scripts/test_api_workflow.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 """Test script for YouTube workflows via the API."""
 
-import requests
+import argparse
 import json
 import time
-import argparse
 from datetime import datetime
+
+import requests
 
 
 def test_niche_scout(host="localhost", port=9000):

--- a/scripts/test_niche_scout_api.py
+++ b/scripts/test_niche_scout_api.py
@@ -20,8 +20,9 @@ import os
 import sys
 import time
 from datetime import datetime
+from typing import Any, Dict, Optional
+
 import requests
-from typing import Dict, Any, Optional
 
 # Test cases with various categories and subcategories
 TEST_CASES = [

--- a/scripts/test_youtube_agent.py
+++ b/scripts/test_youtube_agent.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
 """Manual test script for YouTube-focused flows in SocialIntelligence Agent."""
 
-import os
+import argparse
 import asyncio
 import json
-import argparse
-from datetime import datetime
+import os
 
 # Add parent directory to path
 import sys
+from datetime import datetime
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Import agent
-from agents.social_intel.flows.youtube_flows import youtube_niche_scout_flow, youtube_blueprint_flow
+from agents.social_intel.flows.youtube_flows import youtube_blueprint_flow, youtube_niche_scout_flow
 
 
 async def test_niche_scout(queries=None):

--- a/scripts/test_youtube_api_key.py
+++ b/scripts/test_youtube_api_key.py
@@ -15,9 +15,10 @@ Options:
 import argparse
 import os
 import sys
-import requests
+from typing import Any, Dict, List, Optional
+
 import dotenv
-from typing import Dict, Any, List, Optional
+import requests
 
 YOUTUBE_API_BASE_URL = "https://www.googleapis.com/youtube/v3"
 

--- a/scripts/utils/cleanup_processed_messages.py
+++ b/scripts/utils/cleanup_processed_messages.py
@@ -3,12 +3,13 @@
 Cleanup job for expired processed messages to maintain deduplication efficiency.
 """
 
-import os
 import asyncio
-import asyncpg
+import os
 from datetime import datetime
-from dotenv import load_dotenv
+
+import asyncpg
 import structlog
+from dotenv import load_dotenv
 
 logger = structlog.get_logger(__name__)
 

--- a/scripts/utils/database_validation.py
+++ b/scripts/utils/database_validation.py
@@ -3,11 +3,12 @@
 Database validation script to ensure all required tables and indexes exist.
 """
 
-import os
 import asyncio
+import os
+
 import asyncpg
-from dotenv import load_dotenv
 import structlog
+from dotenv import load_dotenv
 
 logger = structlog.get_logger(__name__)
 

--- a/scripts/utils/service_health_check.py
+++ b/scripts/utils/service_health_check.py
@@ -4,9 +4,10 @@ Service health check script to validate all services are running.
 """
 
 import asyncio
-import aiohttp
 import sys
-from typing import Dict, Any, List
+from typing import Any, Dict, List
+
+import aiohttp
 
 SERVICES = {
     "alfred-bot": {"port": 8011, "health_endpoint": "/health/health"},

--- a/services/_template/app/main.py
+++ b/services/_template/app/main.py
@@ -2,11 +2,12 @@
 Template service with standardized health and metrics endpoints.
 """
 
-from fastapi import FastAPI, Response
 import json
 import logging
 import os
-from typing import Dict, Any
+from typing import Any, Dict
+
+from fastapi import FastAPI, Response
 
 # Initialize FastAPI app
 app = FastAPI(

--- a/services/alfred-bot/app/main.py
+++ b/services/alfred-bot/app/main.py
@@ -1,12 +1,13 @@
-from fastapi import FastAPI, Request
-from slack_bolt.adapter.fastapi import SlackRequestHandler
-from slack_bolt import App
 import os
-import structlog
-import redis
 from contextlib import asynccontextmanager
 
-from libs.a2a_adapter import A2AEnvelope, PubSubTransport, SupabaseTransport, PolicyMiddleware
+import redis
+import structlog
+from fastapi import FastAPI, Request
+from slack_bolt import App
+from slack_bolt.adapter.fastapi import SlackRequestHandler
+
+from libs.a2a_adapter import A2AEnvelope, PolicyMiddleware, PubSubTransport, SupabaseTransport
 from libs.agent_core.health import create_health_app
 
 logger = structlog.get_logger(__name__)

--- a/services/financial-tax/app/main.py
+++ b/services/financial-tax/app/main.py
@@ -1,23 +1,24 @@
 """Financial Tax Service FastAPI Application"""
 
-from fastapi import FastAPI, HTTPException, Request, Security
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from fastapi.middleware.cors import CORSMiddleware
-from contextlib import asynccontextmanager
 import os
-import structlog
-import redis
-from prometheus_client import Counter, Histogram, Gauge
+from contextlib import asynccontextmanager
 
-from libs.a2a_adapter import A2AEnvelope, PubSubTransport, SupabaseTransport, PolicyMiddleware
-from libs.agent_core.health import create_health_app
+import redis
+import structlog
+from fastapi import FastAPI, HTTPException, Request, Security
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from prometheus_client import Counter, Gauge, Histogram
+
 from agents.financial_tax import (
+    ComplianceCheckRequest,
+    FinancialAnalysisRequest,
     FinancialTaxAgent,
     TaxCalculationRequest,
-    FinancialAnalysisRequest,
-    ComplianceCheckRequest,
     TaxRateRequest,
 )
+from libs.a2a_adapter import A2AEnvelope, PolicyMiddleware, PubSubTransport, SupabaseTransport
+from libs.agent_core.health import create_health_app
 
 logger = structlog.get_logger(__name__)
 

--- a/services/legal-compliance/app/main.py
+++ b/services/legal-compliance/app/main.py
@@ -1,23 +1,24 @@
 """Legal Compliance Service FastAPI Application"""
 
-from fastapi import FastAPI, HTTPException, Request, Security
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from fastapi.middleware.cors import CORSMiddleware
-from contextlib import asynccontextmanager
 import os
-import structlog
-import redis
-from prometheus_client import Counter, Histogram, Gauge
+from contextlib import asynccontextmanager
 
-from libs.a2a_adapter import A2AEnvelope, PubSubTransport, SupabaseTransport, PolicyMiddleware
-from libs.agent_core.health import create_health_app
+import redis
+import structlog
+from fastapi import FastAPI, HTTPException, Request, Security
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from prometheus_client import Counter, Gauge, Histogram
+
 from agents.legal_compliance import (
-    LegalComplianceAgent,
     ComplianceAuditRequest,
-    DocumentAnalysisRequest,
-    RegulationCheckRequest,
     ContractReviewRequest,
+    DocumentAnalysisRequest,
+    LegalComplianceAgent,
+    RegulationCheckRequest,
 )
+from libs.a2a_adapter import A2AEnvelope, PolicyMiddleware, PubSubTransport, SupabaseTransport
+from libs.agent_core.health import create_health_app
 
 logger = structlog.get_logger(__name__)
 

--- a/services/social-intel/app/blueprint.py
+++ b/services/social-intel/app/blueprint.py
@@ -10,7 +10,7 @@ import json
 import os
 import time
 from datetime import datetime
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
 

--- a/services/social-intel/app/database/__init__.py
+++ b/services/social-intel/app/database/__init__.py
@@ -4,9 +4,10 @@ Provides pool management and query utilities.
 """
 
 import os
+from typing import Any, Dict, List, Optional
+
 import asyncpg
 import structlog
-from typing import List, Dict, Any, Optional
 
 logger = structlog.get_logger(__name__)
 

--- a/services/social-intel/app/health_check.py
+++ b/services/social-intel/app/health_check.py
@@ -2,17 +2,17 @@
 Enhanced health check implementation for the Social Intelligence service.
 """
 
+import asyncio
 import os
 import time
-import asyncio
-import aiohttp
-from typing import Dict, Any
-import structlog
-from fastapi import APIRouter, Response, status
+from typing import Any, Dict
 
-from app.metrics import OFFLINE_MODE_GAUGE
+import aiohttp
+import structlog
 from app.database import get_pool
+from app.metrics import OFFLINE_MODE_GAUGE
 from app.utils.circuit_breaker import CircuitBreaker
+from fastapi import APIRouter, Response, status
 
 logger = structlog.get_logger(__name__)
 

--- a/services/social-intel/app/main.py
+++ b/services/social-intel/app/main.py
@@ -1,30 +1,30 @@
 """Social Intelligence Service Main Application."""
 
-from fastapi import FastAPI, HTTPException, Query, Body, Request
-from contextlib import asynccontextmanager
-import os
-import structlog
 import asyncio
-import redis
-import yaml
-from typing import Dict, List, Any, Optional
+import os
+from contextlib import asynccontextmanager
 from datetime import datetime
-from fastapi.responses import HTMLResponse, JSONResponse
-from fastapi.staticfiles import StaticFiles
-from fastapi.openapi.utils import get_openapi
+from typing import Any, Dict, List, Optional
 
-from app.niche_scout import NicheScout
+import redis
+import structlog
+import yaml
 from app.blueprint import SeedToBlueprint
+from app.niche_scout import NicheScout
 from app.workflow_endpoints import (
-    get_workflow_result,
-    get_workflow_history,
     get_scheduled_workflows,
+    get_workflow_history,
+    get_workflow_result,
     schedule_workflow,
 )
+from fastapi import Body, FastAPI, HTTPException, Query, Request
+from fastapi.openapi.utils import get_openapi
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
 
-from libs.a2a_adapter import PubSubTransport, SupabaseTransport, PolicyMiddleware
-from libs.agent_core.health import create_health_app
 from agents.social_intel.agent import SocialIntelAgent
+from libs.a2a_adapter import PolicyMiddleware, PubSubTransport, SupabaseTransport
+from libs.agent_core.health import create_health_app
 
 logger = structlog.get_logger(__name__)
 
@@ -48,7 +48,7 @@ social_agent = SocialIntelAgent(
 async def lifespan(app: FastAPI):
     """Manage application lifecycle."""
     # Import database module here to avoid circular imports
-    from app.database import get_pool, close_pool
+    from app.database import close_pool, get_pool
 
     # Startup
     await supabase_transport.connect()

--- a/services/social-intel/app/metrics.py
+++ b/services/social-intel/app/metrics.py
@@ -3,7 +3,8 @@ Enhanced Prometheus metrics for the Social Intelligence service.
 """
 
 import time
-from prometheus_client import Counter, Histogram, Gauge, Summary
+
+from prometheus_client import Counter, Gauge, Histogram, Summary
 
 # Request metrics
 SI_REQUESTS_TOTAL = Counter(

--- a/services/social-intel/app/metrics_enhanced.py
+++ b/services/social-intel/app/metrics_enhanced.py
@@ -3,7 +3,8 @@ Enhanced Prometheus metrics for the Social Intelligence service.
 """
 
 import time
-from prometheus_client import Counter, Histogram, Gauge, Summary
+
+from prometheus_client import Counter, Gauge, Histogram, Summary
 
 # Request metrics
 SI_REQUESTS_TOTAL = Counter(

--- a/services/social-intel/app/niche_scout.py
+++ b/services/social-intel/app/niche_scout.py
@@ -10,21 +10,21 @@ import json
 import os
 import time
 from datetime import datetime
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
+from app.database import niche_repository
+from app.metrics import (
+    NICHE_OPPORTUNITY_SCORE,
+    NICHE_SCOUT_RESULTS_COUNT,
+    SI_LATENCY_SECONDS,
+    SI_REQUESTS_TOTAL,
+    LatencyTimer,
+)
 
 # Use simple reports instead of HTML templates
 from app.simple_reports import generate_niche_scout_report
-from app.youtube_api import get_trends_by_category, YouTubeAPIError
-from app.database import niche_repository
-from app.metrics import (
-    SI_REQUESTS_TOTAL,
-    SI_LATENCY_SECONDS,
-    NICHE_SCOUT_RESULTS_COUNT,
-    NICHE_OPPORTUNITY_SCORE,
-    LatencyTimer,
-)
+from app.youtube_api import YouTubeAPIError, get_trends_by_category
 
 logger = structlog.get_logger(__name__)
 

--- a/services/social-intel/app/reports.py
+++ b/services/social-intel/app/reports.py
@@ -1,9 +1,9 @@
 """Report generation utilities for Social Intelligence Agent."""
 
-import os
 import json
+import os
 from datetime import datetime
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 from jinja2 import Environment, FileSystemLoader
 

--- a/services/social-intel/app/simple_reports.py
+++ b/services/social-intel/app/simple_reports.py
@@ -1,9 +1,9 @@
 """Simple report generation without HTML templates."""
 
-import os
 import json
+import os
 from datetime import datetime
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 
 def generate_niche_scout_report(

--- a/services/social-intel/app/workflow_endpoints.py
+++ b/services/social-intel/app/workflow_endpoints.py
@@ -2,11 +2,12 @@
 Fixed workflow endpoints module to address datetime parsing issues.
 """
 
-import os
-import json
 import glob
-from typing import Dict, List, Any, Optional
+import json
+import os
 from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
 import structlog
 
 logger = structlog.get_logger(__name__)

--- a/services/social-intel/app/youtube_api.py
+++ b/services/social-intel/app/youtube_api.py
@@ -5,11 +5,12 @@ This module provides functions to interact with the YouTube Data API v3 for fetc
 trends, statistics, and channel data.
 """
 
-import os
 import asyncio
 import json
+import os
 from datetime import datetime
-from typing import Dict, List, Any, Optional
+from typing import Any, Dict, List, Optional
+
 import aiohttp
 import structlog
 

--- a/services/social-intel/fix_workflow_endpoints.py
+++ b/services/social-intel/fix_workflow_endpoints.py
@@ -2,11 +2,12 @@
 Fixed workflow endpoints module to address datetime parsing issues.
 """
 
-import os
-import json
 import glob
-from typing import Dict, List, Any, Optional
+import json
+import os
 from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
 import structlog
 
 logger = structlog.get_logger(__name__)

--- a/services/social-intel/tests/unit/test_features.py
+++ b/services/social-intel/tests/unit/test_features.py
@@ -2,11 +2,12 @@
 Unit tests for the features table and opportunity scoring.
 """
 
-import os
 import asyncio
-import pytest
-import asyncpg
+import os
 from datetime import datetime
+
+import asyncpg
+import pytest
 
 # Set test database URL
 os.environ["DATABASE_URL"] = os.environ.get(

--- a/services/social-intel/tests/unit/test_metrics.py
+++ b/services/social-intel/tests/unit/test_metrics.py
@@ -3,17 +3,16 @@ Unit tests for the metrics module.
 """
 
 import pytest
-from prometheus_client import REGISTRY
-
 from app.metrics import (
-    SI_LATENCY_SECONDS,
-    SI_REQUESTS_TOTAL,
-    NICHE_SCOUT_RESULTS_COUNT,
-    WORKER_LAG_SECONDS,
     DB_QUERY_SECONDS,
     NICHE_OPPORTUNITY_SCORE,
+    NICHE_SCOUT_RESULTS_COUNT,
+    SI_LATENCY_SECONDS,
+    SI_REQUESTS_TOTAL,
+    WORKER_LAG_SECONDS,
     LatencyTimer,
 )
+from prometheus_client import REGISTRY
 
 
 def test_si_latency_seconds_buckets():

--- a/slack-bot/src/app.py
+++ b/slack-bot/src/app.py
@@ -1,6 +1,7 @@
-import os
 import logging
-from flask import Flask, request, jsonify
+import os
+
+from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)

--- a/standalone_test.py
+++ b/standalone_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Standalone test script for YouTube workflows."""
 
-import os
 import json
+import os
 import sys
 from datetime import datetime
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,14 @@
-import pytest
 import asyncio
 import os
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock
+
 import asyncpg
+import pytest
 import redis
 from google.cloud import pubsub_v1
 
-from libs.a2a_adapter import PubSubTransport, SupabaseTransport, PolicyMiddleware
+from libs.a2a_adapter import PolicyMiddleware, PubSubTransport, SupabaseTransport
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/agents/financial_tax/test_agent_integration.py
+++ b/tests/integration/agents/financial_tax/test_agent_integration.py
@@ -1,18 +1,19 @@
 """Integration tests for Financial Tax Agent"""
 
-import pytest
 import asyncio
 import os
 from datetime import datetime
 
+import pytest
+
 from agents.financial_tax.agent import FinancialTaxAgent
-from libs.a2a_adapter import A2AEnvelope, PubSubTransport, SupabaseTransport, PolicyMiddleware
 from agents.financial_tax.models import (
-    TaxCalculationRequest,
-    FinancialAnalysisRequest,
     ComplianceCheckRequest,
+    FinancialAnalysisRequest,
+    TaxCalculationRequest,
     TaxRateRequest,
 )
+from libs.a2a_adapter import A2AEnvelope, PolicyMiddleware, PubSubTransport, SupabaseTransport
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/financial_tax/test_integration.py
+++ b/tests/integration/financial_tax/test_integration.py
@@ -1,13 +1,14 @@
 """Integration tests for Financial Tax Agent"""
 
-import pytest
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from agents.financial_tax import FinancialTaxAgent
-from agents.financial_tax.models import TaxJurisdiction, EntityType
+from agents.financial_tax.models import EntityType, TaxJurisdiction
 from libs.a2a_adapter import A2AEnvelope, PubSubTransport, SupabaseTransport
 
 

--- a/tests/integration/test_exactly_once_processing.py
+++ b/tests/integration/test_exactly_once_processing.py
@@ -1,8 +1,9 @@
-import pytest
 import asyncio
-import asyncpg
 import os
 from datetime import datetime, timedelta
+
+import asyncpg
+import pytest
 
 from libs.a2a_adapter import A2AEnvelope, SupabaseTransport
 

--- a/tests/test_youtube_workflows.py
+++ b/tests/test_youtube_workflows.py
@@ -1,14 +1,15 @@
 """Tests for YouTube workflows in SocialIntelligence Agent."""
 
-import os
 import asyncio
-import pytest
 import json
+import os
 from datetime import datetime
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from agents.social_intel.agent import SocialIntelAgent
-from agents.social_intel.models.youtube_models import NicheScoutResult, BlueprintResult
+from agents.social_intel.models.youtube_models import BlueprintResult, NicheScoutResult
 from agents.social_intel.models.youtube_vectors import YouTubeVectorStorage
 from libs.a2a_adapter import A2AEnvelope
 

--- a/tests/unit/agents/financial_tax/test_agent.py
+++ b/tests/unit/agents/financial_tax/test_agent.py
@@ -1,21 +1,22 @@
 """Tests for Financial Tax Agent"""
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from agents.financial_tax.agent import FinancialTaxAgent
-from libs.a2a_adapter import A2AEnvelope, PubSubTransport, SupabaseTransport, PolicyMiddleware
 from agents.financial_tax.models import (
-    TaxCalculationRequest,
-    TaxCalculationResponse,
-    FinancialAnalysisRequest,
-    FinancialAnalysisResponse,
     ComplianceCheckRequest,
     ComplianceCheckResponse,
+    FinancialAnalysisRequest,
+    FinancialAnalysisResponse,
+    TaxCalculationRequest,
+    TaxCalculationResponse,
     TaxRateRequest,
     TaxRateResponse,
 )
+from libs.a2a_adapter import A2AEnvelope, PolicyMiddleware, PubSubTransport, SupabaseTransport
 
 
 @pytest.fixture

--- a/tests/unit/agents/financial_tax/test_chains.py
+++ b/tests/unit/agents/financial_tax/test_chains.py
@@ -1,26 +1,27 @@
 """Tests for Financial Tax Agent chains"""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 from langchain_openai import ChatOpenAI
 
 from agents.financial_tax.chains import (
-    TaxCalculationChain,
-    FinancialAnalysisChain,
     ComplianceCheckChain,
+    FinancialAnalysisChain,
     RateLookupChain,
+    TaxCalculationChain,
 )
 from agents.financial_tax.models import (
-    TaxCalculationRequest,
-    TaxCalculationResponse,
-    FinancialAnalysisRequest,
-    FinancialAnalysisResponse,
     ComplianceCheckRequest,
     ComplianceCheckResponse,
+    EntityType,
+    FinancialAnalysisRequest,
+    FinancialAnalysisResponse,
+    TaxCalculationRequest,
+    TaxCalculationResponse,
+    TaxJurisdiction,
     TaxRateRequest,
     TaxRateResponse,
-    TaxJurisdiction,
-    EntityType,
 )
 
 

--- a/tests/unit/agents/financial_tax/test_models.py
+++ b/tests/unit/agents/financial_tax/test_models.py
@@ -1,18 +1,19 @@
 """Tests for Financial Tax Agent models"""
 
-import pytest
 from datetime import datetime
+
+import pytest
 from langchain.pydantic_v1 import ValidationError
 
 from agents.financial_tax.models import (
-    TaxJurisdiction,
-    EntityType,
-    TaxCalculationRequest,
-    TaxCalculationResponse,
-    FinancialAnalysisRequest,
-    FinancialAnalysisResponse,
     ComplianceCheckRequest,
     ComplianceCheckResponse,
+    EntityType,
+    FinancialAnalysisRequest,
+    FinancialAnalysisResponse,
+    TaxCalculationRequest,
+    TaxCalculationResponse,
+    TaxJurisdiction,
     TaxRateRequest,
     TaxRateResponse,
 )

--- a/tests/unit/test_base_agent.py
+++ b/tests/unit/test_base_agent.py
@@ -1,10 +1,11 @@
-import pytest
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from libs.agent_core import BaseAgent
+import pytest
+
 from libs.a2a_adapter import A2AEnvelope
+from libs.agent_core import BaseAgent
 
 
 class TestAgent(BaseAgent):

--- a/tests/unit/test_envelope.py
+++ b/tests/unit/test_envelope.py
@@ -1,5 +1,6 @@
-import pytest
 from datetime import datetime
+
+import pytest
 
 from libs.a2a_adapter import A2AEnvelope, Artifact
 

--- a/whatsapp-adapter/src/app.py
+++ b/whatsapp-adapter/src/app.py
@@ -1,6 +1,7 @@
-import os
 import logging
-from flask import Flask, request, jsonify
+import os
+
+from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)

--- a/youtube-test-env/test_niche_scout.py
+++ b/youtube-test-env/test_niche_scout.py
@@ -2,15 +2,17 @@
 """Simple test script for YouTube Niche-Scout workflow."""
 
 import asyncio
-import os
 import json
-import pandas as pd
-import numpy as np
+import os
 from datetime import datetime
-import umap
+
+import numpy as np
+import pandas as pd
 import sklearn.cluster as skc
-from youtubesearchpython import VideosSearch
+import umap
 from pytrends.request import TrendReq
+from youtubesearchpython import VideosSearch
+
 
 async def search_videos(query, limit=100):
     """Search for videos using the given query."""


### PR DESCRIPTION
This PR fixes the CI build failures caused by duplicate module names in the mypy type checking.

## Changes
- Added exclusion patterns in pyproject.toml to skip non-essential directories
- Created a mypy wrapper script that properly applies exclusions
- Updated CI workflows to use the wrapper script

This fix will unblock the ongoing PRs for code style enforcement, particularly the isort formatting PR (#17), which was failing due to mypy errors in backup/archive files.

The exclusions specifically target:
- cleanup-temp directory
- docs/archive directory
- node_modules directory

These directories contain duplicate module names but aren't part of the core codebase that needs type checking.