### PR TITLE
chore: Mark legacy health check scripts as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applied Black 24.1.1 formatting across entire codebase
 - Updated CI pipeline to enforce strict Black checks
 - Standardized code formatting for better maintainability
+- Marked legacy health check scripts as deprecated
+
+## [0.3.0-healthcheck-full] - 2025-05-14
+
+### Added
+- Complete standardization of healthcheck binary v0.4.0 across all services
+- Added metrics port exposure (9091) for all containers
+- Created audit script to identify legacy healthcheck implementations
+- Created bulk update script for standardizing healthcheck across services
+- Added verification script to ensure metrics are properly exported
+- Enhanced CI validation to detect services without proper health checks
+- Updated Prometheus configuration to include all service metrics endpoints
+
+### Changed
+- Updated all remaining Dockerfiles to use healthcheck binary v0.4.0
+- Standardized health check configuration across services
+- Added consistent metrics port exposure for monitoring
+- Enhanced documentation of health check implementation
+
+### Removed
+- Deprecated service-specific health probe implementations
 
 ## [0.2.0-phase1] - 2025-05-13
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,4 +1,10 @@
-#\!/bin/bash
+#!/bin/bash
+# *********************************************************************
+# DEPRECATED: This script is deprecated and will be removed in a future version.
+# Please use the healthcheck binary v0.4.0 instead, which is now standardized
+# across all services. See PR #22 for details.
+# *********************************************************************
+
 # Extract URL from args
 URL=""
 while [[ $# -gt 0 ]]; do

--- a/scripts/bump-healthcheck.sh
+++ b/scripts/bump-healthcheck.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# *********************************************************************
+# DEPRECATED: This script is deprecated and will be removed in a future version.
+# Please use scripts/update-healthcheck-binary.sh instead, which is now the
+# standard way to update healthcheck versions across all services.
+# See PR #22 for details.
+# *********************************************************************
+
 # Script to bump the healthcheck binary version across all services
 # Usage: ./scripts/bump-healthcheck.sh <new_version>
 # Example: ./scripts/bump-healthcheck.sh 0.5.0
@@ -64,6 +71,7 @@ update_changelog() {
 }
 
 # Main execution
+echo "DEPRECATED: This script is deprecated. Please use scripts/update-healthcheck-binary.sh instead."
 echo "Bumping healthcheck binary from v$CURRENT_VERSION to v$NEW_VERSION"
 check_version_format
 

--- a/scripts/detect-deprecated-health-scripts.sh
+++ b/scripts/detect-deprecated-health-scripts.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Script to detect usage of deprecated health check scripts in the codebase
+# This helps with the migration to the standardized healthcheck binary v0.4.0
+
+set -euo pipefail
+
+echo "Detecting usage of deprecated health check scripts..."
+
+# List of deprecated scripts
+DEPRECATED_SCRIPTS=(
+  "healthcheck.sh"
+  "scripts/bump-healthcheck.sh"
+  "update-health-endpoints.sh"
+)
+
+FOUND=0
+
+# Check for direct references in shell scripts, Dockerfiles, etc.
+for script in "${DEPRECATED_SCRIPTS[@]}"; do
+  echo "Checking for references to $script..."
+  
+  # Find direct references to the script name
+  REFERENCES=$(grep -r --include="*.sh" --include="*.yml" --include="*.yaml" --include="Dockerfile*" --include="*.json" "$script" . --exclude-dir={node_modules,.git,backup,archive} || true)
+  
+  if [ -n "$REFERENCES" ]; then
+    echo "⚠️ Found references to deprecated script $script:"
+    echo "$REFERENCES" | sed 's/^/  - /'
+    echo ""
+    FOUND=$((FOUND + 1))
+  else
+    echo "✅ No references found to $script"
+  fi
+done
+
+# Summary
+if [ $FOUND -eq 0 ]; then
+  echo "🎉 No references to deprecated health check scripts found!"
+  echo "The codebase appears to be fully migrated to the standardized healthcheck binary v0.4.0."
+else
+  echo "⚠️ Found references to $FOUND deprecated health check scripts."
+  echo "Please update these references to use the standardized healthcheck binary v0.4.0 instead."
+  echo "See PR #22 for details on the standardized health check approach."
+fi

--- a/update-health-endpoints.sh
+++ b/update-health-endpoints.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
+# *********************************************************************
+# DEPRECATED: This script is deprecated and will be removed in a future version.
+# Please use the healthcheck binary v0.4.0 instead, which is now standardized
+# across all services. See PR #22 for details.
+# *********************************************************************
 
+echo "DEPRECATED: This script is deprecated. See comments in the script for details."
 echo "Updating health endpoints to use simple /health pattern..."
 
 cd /home/locotoki/projects/alfred-agent-platform-v2


### PR DESCRIPTION
This PR marks legacy health check scripts as deprecated instead of removing them, to avoid breaking existing code that might still depend on them.

## Changes
- Added deprecation notices to these legacy scripts:
  - healthcheck.sh
  - scripts/bump-healthcheck.sh
  - update-health-endpoints.sh
- Created scripts/detect-deprecated-health-scripts.sh to help identify remaining uses of deprecated scripts
- Updated CHANGELOG.md

This approach is less disruptive than removing the scripts entirely, while still encouraging migration to the standardized health check approach. The scripts will continue to function, but with clear warnings about their deprecated status.