### PR TITLE
chore: Move Phase 6C entry to v0.6.1-rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- TBD
+
+## [0.6.1-rc1] - 2025-05-15
+
+### Added
 - Phase 6C: AI orchestration PoC (n8n + CrewAI)
 
 ## [0.6.0] - 2025-05-15


### PR DESCRIPTION
## Summary
- Move the AI orchestration PoC changelog entry from Unreleased to the new v0.6.1-rc1 release section
- Prepare the CHANGELOG.md for the next release cycle with empty TBD placeholder in Unreleased section

## Test plan
- Verify CHANGELOG.md formatting is correct
- Ensure the Phase 6C entry appears under the correct version section

🤖 Generated with [Claude Code](https://claude.ai/code)