### PR TITLE
test: demo docs-only PR for CI optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A scalable, modular AI agent platform built with Docker, Supabase, and Pub/Sub messaging.
 
+## Documentation Updates
+This section demonstrates the CI optimization for docs-only changes.
+
 [![Black Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Black Format Check](https://github.com/locotoki/alfred-agent-platform-v2/actions/workflows/black-check.yml/badge.svg?branch=main)](https://github.com/locotoki/alfred-agent-platform-v2/actions/workflows/black-check.yml)
 


### PR DESCRIPTION
This is a test PR to demonstrate CI optimization for documentation-only changes.

## Purpose
- Verify that heavy jobs (lint-and-test, integration-test, build-images) are skipped
- Only lightweight jobs should run for this docs-only change
- This tests the optimization from PR #53

## Changes
- Minor documentation update to README.md
- No code changes

This PR can be closed after validation.