### PR TITLE
ci: push images to GHCR on main using GHCR_PAT

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy Images
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  push-image:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: staging
+    strategy:
+      matrix:
+        service:
+          - slack_mcp_gateway
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Login to GHCR
+        run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+      
+      - name: Build and push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/alfred-platform/${{ matrix.service }}:${{ github.sha }}
+          STAGING_TAG=ghcr.io/${{ github.repository_owner }}/alfred-platform/${{ matrix.service }}:latest
+          
+          cd services/${{ matrix.service }}
+          docker build -t $IMAGE_ID .
+          docker tag $IMAGE_ID $STAGING_TAG
+          docker push $IMAGE_ID
+          docker push $STAGING_TAG


### PR DESCRIPTION
## Summary

This PR adds a dedicated deploy workflow that runs only on the main branch to push Docker images to GitHub Container Registry (GHCR) using a Personal Access Token.

## Problem

During PR #55, the CI build succeeded but pushing to GHCR failed with 403 Forbidden. This is expected behavior as:
1. PR workflows don't have access to repository secrets for security reasons
2. The default GITHUB_TOKEN doesn't have sufficient permissions for GHCR push

## Solution

- Add new `.github/workflows/deploy.yml` that runs only on `main` branch
- Uses `GHCR_PAT` secret from the `staging` environment
- Builds and pushes images with both SHA and latest tags

## Setup Required

Before merging, the repository administrator needs to:
1. Create a PAT (Personal Access Token) with `write:packages` scope
2. Add it to GitHub Settings → Secrets → Environments → staging as `GHCR_PAT`

## Testing

After merge, this workflow will automatically:
1. Build the slack_mcp_gateway image
2. Push to GHCR with both commit SHA and `latest` tags
3. Make the image available for deployment

🤖 Generated with [Claude Code](https://claude.ai/code)