### PR TITLE
fix(ci): correct repository name in GHCR image path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,8 @@ jobs:
       
       - name: Build and push image
         run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/alfred-platform/${{ matrix.service }}:${{ github.sha }}
-          STAGING_TAG=ghcr.io/${{ github.repository_owner }}/alfred-platform/${{ matrix.service }}:latest
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/alfred-agent-platform-v2/${{ matrix.service }}:${{ github.sha }}
+          STAGING_TAG=ghcr.io/${{ github.repository_owner }}/alfred-agent-platform-v2/${{ matrix.service }}:latest
           
           cd services/${{ matrix.service }}
           docker build -t $IMAGE_ID .


### PR DESCRIPTION
## Summary
- Fixed the repository name in the deploy workflow GHCR path from alfred-platform to alfred-agent-platform-v2
- This was causing the permission_denied error as the PAT was scoped to the correct repository but the workflow was trying to push to a non-existent path

## Changes
- Updated the IMAGE_ID and STAGING_TAG paths in deploy.yml to use the correct repository name

## Related
- Fixes the deploy workflow that was failing in PR 56