### PR TITLE
fix(ci): use GITHUB_TOKEN for GHCR authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,11 @@ jobs:
         uses: docker/setup-buildx-action@v2
       
       - name: Login to GHCR
-        run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Build and push image
         run: |


### PR DESCRIPTION
## Summary
- Switches from GHCR_PAT to GITHUB_TOKEN for GitHub Container Registry authentication
- Uses docker/login-action@v3 for more reliable authentication
- Should resolve the permission_denied errors we've been seeing

## Changes  
- Changed deploy.yml to use GITHUB_TOKEN instead of GHCR_PAT
- Using docker/login-action for standardized authentication

## Related
- Follows up on #58 to resolve deploy workflow failures