### PR TITLE
fix: implement proper Slack release notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Announce Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to announce (tag or branch)'
+        required: true
+        default: 'main'
+  release:
+    types: [published]
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+      
+      - name: Get version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          else
+            VERSION="${{ github.event.inputs.ref }}"
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Announce deploy
+        env:
+          SLACK_RELEASE_WEBHOOK: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
+        run: |
+          MESSAGE=":rocket: Released ${{ steps.version.outputs.VERSION }}"
+          
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            MESSAGE="$MESSAGE - ${{ github.event.release.name }}"
+          fi
+          
+          ./scripts/slack/announce-deploy.sh "$MESSAGE"

--- a/scripts/slack/announce-deploy.sh
+++ b/scripts/slack/announce-deploy.sh
@@ -1,9 +1,41 @@
-#\!/bin/bash
-# Slack deployment announcement
+#!/bin/bash
+# Slack deployment announcement with proper webhook support
+
+set -euo pipefail
 
 MESSAGE="$1"
+
+if [ -z "$MESSAGE" ]; then
+    echo "Error: Message parameter required"
+    echo "Usage: $0 \"Your message here\""
+    exit 1
+fi
+
+# Check for webhook URL
+WEBHOOK_URL="${SLACK_RELEASE_WEBHOOK:-}"
+
+if [ -z "$WEBHOOK_URL" ]; then
+    echo "Warning: SLACK_RELEASE_WEBHOOK not set. Running in dry-run mode."
+    echo "Would send to Slack: $MESSAGE"
+    echo "$MESSAGE" >> /tmp/slack-announcements.log
+    exit 0
+fi
+
+# Send to Slack via webhook
 echo "Sending to Slack: $MESSAGE"
 
-# In a real environment, this would use slack CLI or webhook
-echo "$MESSAGE" >> /tmp/slack-announcements.log
-echo "Announcement sent successfully"
+RESPONSE=$(curl -s -w '\n%{http_code}' -X POST -H 'Content-type: application/json' \
+    --data "{\"text\":\"$MESSAGE\"}" \
+    "$WEBHOOK_URL")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | head -n-1)
+
+if [ "$HTTP_CODE" = "200" ]; then
+    echo "✅ Slack notification sent successfully"
+    exit 0
+else
+    echo "Error: Failed to send Slack notification (HTTP $HTTP_CODE)"
+    echo "Response: $BODY"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Replace stub announce script with proper curl/webhook implementation
- Add GitHub workflow for automated release announcements
- Handle missing webhook gracefully (dry-run mode)

## Details
- Script checks for \ environment variable
- Falls back to dry-run mode if not set
- Proper error handling with HTTP status codes
- CI workflow triggers on release publish or manual dispatch

## Testing
- Local dry-run: ✅ Works without webhook
- Syntax validation: ✅ Passes \
- Error handling: ✅ Clear messages

## Required Setup
Add \ secret in GitHub repository settings