### PR TITLE
ci: add alert grouping acceptance workflow (#99)

### DIFF
--- a/.github/workflows/alert-grouping.yml
+++ b/.github/workflows/alert-grouping.yml
@@ -1,0 +1,51 @@
+name: Alert Grouping CI
+
+on:
+  push:
+    branches:
+      - feat/alert-group-*
+      - feat/phase8.3-sprint1
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'alfred/alerts/**'
+      - 'tests/backend/alert_group/**'
+      - '.github/workflows/alert-grouping.yml'
+
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  test-alert-grouping:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+          pip install -r requirements.txt
+      
+      - name: Run alert grouping tests
+        run: |
+          pytest tests/backend/alert_group/ -v -k alert_group --cov=alfred.alerts --cov-report=xml
+      
+      - name: Check coverage
+        run: |
+          coverage report
+          # Ensure 85% coverage for alfred.alerts package
+          coverage report --fail-under=85 --include="alfred/alerts/*"
+      
+      - name: Upload coverage reports
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          flags: alert-grouping
+          name: alert-grouping-coverage


### PR DESCRIPTION
## Summary
Adds CI workflow for alert grouping feature testing.

### Changes
- Set up Python 3.11
- Run pytest on alert_group tests
- Report coverage with 85% threshold
- Upload to codecov

Fixes #99