### PR TITLE
ops: C-0 scripts inventory

### DIFF
--- a/docs/spring_clean/README.md
+++ b/docs/spring_clean/README.md
@@ -1,0 +1,24 @@
+# Spring Clean Phase C-0: Scripts Inventory
+
+Generated on: 2025-05-19
+
+## Overview
+
+This directory contains the results of the Spring Clean Phase C-0, which focuses on inventorying and analyzing all scripts in the repository.
+
+## Files
+
+- `scripts_inventory.csv`: Raw list of all shell and Python scripts in the repository
+- `scripts_inventory_enhanced.csv`: Enhanced inventory with usage status and references
+- `scripts_usage_report.md`: Markdown report with summary statistics and orphan scripts list
+- `stale_scripts_report.md`: Vulture output showing potentially dead code
+
+## Key Findings
+
+See `scripts_usage_report.md` for detailed analysis of script usage across the codebase.
+
+## Next Steps
+
+1. Review orphan scripts for potential removal
+2. Update documentation for actively used scripts
+3. Consider consolidating similar functionality

--- a/docs/spring_clean/scripts_usage_report.md
+++ b/docs/spring_clean/scripts_usage_report.md
@@ -1,0 +1,21 @@
+# Scripts Usage Analysis
+
+## Summary
+
+- Total scripts: 23
+- Used scripts: 14
+- Orphan scripts: 9
+
+## Orphan Scripts
+
+| Script | Type |
+|--------|------|
+| scripts/healthcheck/rebuild-services.sh | Shell |
+| scripts/healthcheck/revert-to-healthcheck-binary.sh | Shell |
+| scripts/monitoring/rollout_manager.sh | Shell |
+| scripts/monitoring/telemetry_watch.sh | Shell |
+| scripts/platform-init-hooks/db-storage-fix.sh | Shell |
+| scripts/utils/alfred-start.sh | Shell |
+| scripts/utils/controlled-restart.sh | Shell |
+| scripts/utils/platform-startup.sh | Shell |
+| scripts/utils/setup_cron_jobs.sh | Shell |

--- a/docs/spring_clean/stale_scripts_report.md
+++ b/docs/spring_clean/stale_scripts_report.md
@@ -1,0 +1,3 @@
+scripts/benchmark_ranker.py:21: unused import 'pd' (90% confidence)
+scripts/benchmark_ranker.py:293: unused variable 'im' (60% confidence)
+scripts/test-diagnostics-local.py:6: unused import 'MagicMock' (90% confidence)

--- a/scripts/analyze_script_usage.py
+++ b/scripts/analyze_script_usage.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Analyze script usage across the repository."""
+
+import csv
+import os
+import subprocess
+from pathlib import Path
+
+
+def check_script_usage(script_path):
+    """Check if a script is referenced in the codebase."""
+    script_name = os.path.basename(script_path)
+    locations_to_check = [
+        'Makefile',
+        '.github/workflows/',
+        'docs/',
+        'README.md',
+        'scripts/',
+        'docker-compose*.yml',
+        'charts/',
+    ]
+
+    found_references = []
+
+    for location in locations_to_check:
+        try:
+            result = subprocess.run(
+                ['grep', '-r', script_name, location],
+                capture_output=True,
+                text=True,
+                cwd='/home/locotoki/projects/alfred-agent-platform-v2',
+            )
+
+            if result.returncode == 0:
+                lines = result.stdout.strip().split('\n')
+                for line in lines:
+                    # Skip the script itself
+                    if not line.startswith(script_path):
+                        found_references.append(line)
+        except Exception:
+            pass
+
+    return 'USED' if found_references else 'ORPHAN', found_references
+
+
+def main():
+    """Process the scripts inventory and add usage status."""
+    with open('scripts_inventory.csv', 'r') as f:
+        scripts = [line.strip() for line in f.readlines()]
+
+    results = []
+
+    for script in scripts:
+        if script:  # Skip empty lines
+            status, refs = check_script_usage(script)
+            results.append(
+                {
+                    'script': script,
+                    'status': status,
+                    'references': len(refs),
+                    'first_reference': refs[0] if refs else '',
+                }
+            )
+
+    # Write enhanced CSV
+    with open('scripts_inventory_enhanced.csv', 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=['script', 'status', 'references', 'first_reference'])
+        writer.writeheader()
+        writer.writerows(results)
+
+    # Write markdown report
+    with open('scripts_usage_report.md', 'w') as f:
+        f.write('# Scripts Usage Analysis\n\n')
+        f.write('## Summary\n\n')
+
+        used_count = sum(1 for r in results if r['status'] == 'USED')
+        orphan_count = sum(1 for r in results if r['status'] == 'ORPHAN')
+
+        f.write(f'- Total scripts: {len(results)}\n')
+        f.write(f'- Used scripts: {used_count}\n')
+        f.write(f'- Orphan scripts: {orphan_count}\n\n')
+
+        f.write('## Orphan Scripts\n\n')
+        f.write('| Script | Type |\n')
+        f.write('|--------|------|\n')
+
+        for result in results:
+            if result['status'] == 'ORPHAN':
+                script_type = 'Shell' if result['script'].endswith('.sh') else 'Python'
+                f.write(f"| {result['script']} | {script_type} |\n")
+
+    print(f'Analysis complete. Found {orphan_count} orphan scripts out of {len(results)} total.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
@alfred-architect-o3

## Summary

Created initial scripts inventory for Spring Clean Phase C-0.

## Changes

- Generated inventory of all shell and Python scripts in  directory
- Ran vulture to identify potential dead code
- Added usage analysis to categorize scripts as USED or ORPHAN
- Created comprehensive documentation in 

## Results

- Total scripts: 23
- Used scripts: 14
- Orphan scripts: 9

See  for details.

## Files

-  - Raw list of scripts
-  - Enhanced with usage data
-  - Summary report
-  - Vulture analysis

## Next Steps

- Review orphan scripts for potential removal
- Update documentation for actively used scripts
- Consider consolidating similar functionality