### PR TITLE
fix: Grafana datasource configuration (SC-181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 - Enhanced grouping algorithm with ML similarity scoring
 - Established repository-wide Black and isort formatting baseline (ops/black-baseline-fix)
+- Fixed PostgreSQL version to v15 to match data directory format (fix/sc-180-postgres-version)
 
 ### Documentation
 - Added comprehensive noise reduction guide in docs/dev/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Enhanced grouping algorithm with ML similarity scoring
 - Established repository-wide Black and isort formatting baseline (ops/black-baseline-fix)
 - Fixed PostgreSQL version to v15 to match data directory format (fix/sc-180-postgres-version)
+- Fixed Grafana datasource configuration to avoid multiple default datasources (fix/sc-181-grafana-datasource)
 
 ### Documentation
 - Added comprehensive noise reduction guide in docs/dev/

--- a/STACK-BOOT-REPORT.md
+++ b/STACK-BOOT-REPORT.md
@@ -1,0 +1,46 @@
+# Local Stack Boot Errors (SC-LS-001)
+
+## Summary of Issues
+The local stack cannot start properly due to several critical issues:
+
+1. **PostgreSQL version incompatibility**: 
+   - Error: `database files are incompatible with server`
+   - Details: The data directory was initialized by PostgreSQL version 15, but the current container uses version 14.18
+   - Impact: Database cannot start
+
+2. **Grafana datasource configuration error**:
+   - Error: `Datasource provisioning error: datasource.yaml config is invalid. Only one datasource per organization can be marked as default`
+   - Details: Multiple datasources are marked as default in the provisioning configuration
+   - Impact: Grafana container keeps restarting
+
+3. **Docker compose file generation issue**:
+   - Error: `Additional property .env-common is not allowed`
+   - Details: The `generate_compose.py` script adds an invalid `.env-common` property to the docker-compose.generated.yml file
+   - Impact: Cannot start the stack with docker compose
+
+4. **Health check script dependency**:
+   - Error: `jq: command not found`
+   - Details: The compose-health-check.sh script requires jq for JSON parsing
+   - Impact: Cannot accurately report on service health
+
+## Service Status
+- Redis: Can run independently but fails as part of the stack
+- PostgreSQL: Cannot start due to version incompatibility
+- Grafana/Prometheus: Cannot start due to configuration errors
+
+## Recommended Actions
+
+1. **Fix PostgreSQL version incompatibility**:
+   - Update Dockerfile to use postgres:15-alpine
+   - OR clean the volume: `docker volume rm alfred-db-postgres-data`
+
+2. **Fix Grafana datasource configuration**:
+   - Review and fix provisioning files to ensure only one datasource is marked as default
+   - Location: monitoring/grafana/provisioning/datasources/datasource.yaml
+
+3. **Fix docker-compose generation script**:
+   - Modify scripts/generate_compose.py to avoid adding the `.env-common` property
+   - A fixed version has been created at scripts/generate_compose_fixed.py
+
+4. **Install jq dependency**:
+   - Run: `apt-get update && apt-get install -y jq`

--- a/adapters/telegram/Dockerfile
+++ b/adapters/telegram/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.10-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8080
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Create directory for Prometheus multiprocess metrics
+RUN mkdir -p /tmp/prometheus && chmod 777 /tmp/prometheus
+
+# Copy application code
+COPY . .
+
+# Create a simple healthcheck script
+RUN echo '#!/bin/sh\ncurl -f http://localhost:$PORT/health || exit 1' > /app/healthcheck.sh && \
+    chmod +x /app/healthcheck.sh
+
+# Expose port
+EXPOSE $PORT
+
+# Set health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 CMD ["/app/healthcheck.sh"]
+
+# Command to run the application
+CMD ["/app/start.sh"]

--- a/adapters/telegram/__init__.py
+++ b/adapters/telegram/__init__.py
@@ -1,0 +1,1 @@
+"""Telegram adapter package for Alfred platform."""

--- a/adapters/telegram/app.py
+++ b/adapters/telegram/app.py
@@ -1,0 +1,184 @@
+"""Telegram adapter for Alfred platform.
+
+This module implements a FastAPI application that serves as a Telegram adapter
+for the Alfred platform. It handles incoming webhook requests from Telegram,
+processes the messages and routes them to Alfred.
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Any, Optional
+
+from fastapi import FastAPI, Request, Response, status
+from fastapi.middleware.cors import CORSMiddleware
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Histogram,
+    generate_latest,
+    multiprocess,
+)
+from telegram import Update
+from telegram.ext import Application, CommandHandler, MessageHandler, filters
+
+# Configure logging
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+
+# Initialize FastAPI app
+app = FastAPI(title="Telegram Adapter", description="Telegram adapter for Alfred Agent Platform")
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Setup Prometheus metrics
+REQUEST_COUNT = Counter(
+    "telegram_adapter_requests_total",
+    "Total number of requests to the Telegram adapter",
+    ["method", "endpoint", "status_code"],
+)
+
+REQUEST_LATENCY = Histogram(
+    "telegram_adapter_request_latency_seconds", "Request latency in seconds", ["method", "endpoint"]
+)
+
+MESSAGE_COUNT = Counter(
+    "telegram_adapter_messages_total",
+    "Total number of messages processed by the Telegram adapter",
+    ["type"],  # type can be "text", "command", etc.
+)
+
+# Get Telegram bot token from environment variables
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+if not TELEGRAM_BOT_TOKEN:
+    logger.error("TELEGRAM_BOT_TOKEN not set in environment variables")
+
+# Initialize the Telegram bot application
+bot_app = Application.builder().token(TELEGRAM_BOT_TOKEN or "").build()
+
+# ALFRED Core service connection - adjust as needed for your environment
+ALFRED_CORE_URL = os.getenv("ALFRED_CORE_URL", "http://agent-core:8011")
+
+
+async def route_to_alfred(user_id: str, message: str) -> Optional[str]:
+    """Route the message to Alfred Core service and get a response.
+
+    This is a placeholder implementation - integrate with your actual Alfred Core API.
+    """
+    try:
+        # Placeholder for actual API call to Alfred
+        # In a real implementation, you would make an HTTP request to your core service
+        logger.info(f"Routing message to Alfred Core: {message}")
+
+        # Simulate a response for now - replace with actual API call
+        response = f"Received your message: {message}"
+        return response
+    except Exception as e:
+        logger.error(f"Error routing message to Alfred: {e}")
+        return None
+
+
+# Command handler for /start
+async def start_command(update: Update, context):
+    """Send a message when the command /start is issued."""
+    user = update.effective_user
+    MESSAGE_COUNT.labels(type="command").inc()
+    await update.message.reply_text(
+        f"Hello {user.first_name}! I am Alfred, your personal assistant."
+    )
+
+
+# Command handler for /help
+async def help_command(update: Update, context):
+    """Send a message when the command /help is issued."""
+    MESSAGE_COUNT.labels(type="command").inc()
+    await update.message.reply_text(
+        "I can help you with a variety of tasks. Just send me a message!"
+    )
+
+
+# Message handler for text messages
+async def message_handler(update: Update, context):
+    """Handle incoming text messages."""
+    user_id = str(update.effective_user.id)
+    message_text = update.message.text
+
+    # Increment message counter
+    MESSAGE_COUNT.labels(type="text").inc()
+
+    # Start timing for latency measurement
+    start_time = time.time()
+
+    # Route the message to Alfred and get a response
+    response = await route_to_alfred(user_id, message_text)
+
+    # Record latency
+    latency = time.time() - start_time
+    REQUEST_LATENCY.labels(method="POST", endpoint="/alfred/message").observe(latency)
+
+    if response:
+        await update.message.reply_text(response)
+    else:
+        await update.message.reply_text("Sorry, I couldn't process your request at the moment.")
+
+
+# Register handlers
+bot_app.add_handler(CommandHandler("start", start_command))
+bot_app.add_handler(CommandHandler("help", help_command))
+bot_app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, message_handler))
+
+# Start the bot in webhook mode
+WEBHOOK_URL = os.getenv("WEBHOOK_URL")
+
+
+@app.post("/telegram/webhook", status_code=status.HTTP_200_OK)
+async def telegram_webhook(req: Request) -> dict:
+    """Handle Telegram webhook updates."""
+    start_time = time.time()
+    try:
+        update_data = await req.json()
+        logger.info(f"Received update: {json.dumps(update_data)}")
+
+        # Process the update
+        update = Update.de_json(update_data, bot_app.bot)
+        await bot_app.process_update(update)
+
+        REQUEST_COUNT.labels(method="POST", endpoint="/telegram/webhook", status_code="200").inc()
+        REQUEST_LATENCY.labels(method="POST", endpoint="/telegram/webhook").observe(
+            time.time() - start_time
+        )
+        return {"ok": True}
+    except Exception as e:
+        logger.error(f"Error processing webhook update: {e}")
+        REQUEST_COUNT.labels(method="POST", endpoint="/telegram/webhook", status_code="500").inc()
+        REQUEST_LATENCY.labels(method="POST", endpoint="/telegram/webhook").observe(
+            time.time() - start_time
+        )
+        return {"ok": False, "error": str(e)}
+
+
+@app.get("/health", status_code=status.HTTP_200_OK)
+async def health_check() -> dict:
+    """Health check endpoint."""
+    REQUEST_COUNT.labels(method="GET", endpoint="/health", status_code="200").inc()
+    return {"status": "healthy", "service": "telegram-adapter"}
+
+
+@app.get("/metrics", status_code=status.HTTP_200_OK)
+async def metrics() -> Any:
+    """Metrics endpoint for Prometheus."""
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry)
+    data = generate_latest(registry)
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/adapters/telegram/compose.yml
+++ b/adapters/telegram/compose.yml
@@ -1,0 +1,10 @@
+services:
+  telegram-adapter:
+    image: ${ALFRED_REGISTRY}/alfred-platform/telegram-adapter:${ALFRED_VERSION}
+    environment:
+      - ALFRED_ENVIRONMENT=${ALFRED_ENVIRONMENT}
+      - ALFRED_LOG_LEVEL=${ALFRED_LOG_LEVEL}
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+    restart: unless-stopped
+    networks:
+      - alfred-network

--- a/adapters/telegram/requirements.txt
+++ b/adapters/telegram/requirements.txt
@@ -1,0 +1,8 @@
+fastapi>=0.100.0
+uvicorn[standard]>=0.23.0
+python-telegram-bot>=21.0
+httpx>=0.24.0
+structlog>=23.1.0
+pydantic>=2.0.0
+prometheus-client>=0.17.0
+jinja2>=3.1.2

--- a/adapters/telegram/start.sh
+++ b/adapters/telegram/start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Simple startup script for the Telegram adapter
+
+set -e
+
+echo "Starting Telegram adapter service..."
+
+# Set default environment variables if not already set
+export ALFRED_LOG_LEVEL=${ALFRED_LOG_LEVEL:-INFO}
+export PORT=${PORT:-8080}
+
+# Check if TELEGRAM_BOT_TOKEN is set
+if [ -z "$TELEGRAM_BOT_TOKEN" ]; then
+    echo "WARNING: TELEGRAM_BOT_TOKEN is not set!"
+    echo "The adapter will start but won't be able to connect to Telegram."
+fi
+
+# Optional: Set webhook URL if provided
+if [ ! -z "$WEBHOOK_URL" ]; then
+    echo "Setting webhook URL to $WEBHOOK_URL"
+    # Here you could add code to register the webhook with Telegram Bot API
+fi
+
+# Start the application
+echo "Starting uvicorn server on 0.0.0.0:$PORT"
+exec uvicorn app:app --host 0.0.0.0 --port $PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -734,6 +734,36 @@ services:
       com.docker.compose.service: "slack-adapter"
       prometheus.metrics.port: "9091"
 
+  # Telegram Adapter Service
+  telegram-adapter:
+    build:
+      context: ./adapters/telegram
+      dockerfile: Dockerfile
+    image: ${ALFRED_REGISTRY}/alfred-platform/telegram-adapter:${ALFRED_VERSION:-latest}
+    container_name: telegram-adapter
+    ports:
+      - "3002:8080"  # Map host port 3002 to container port 8080
+      - "9129:9091"  # Metrics port
+    environment:
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+      - ALFRED_ENVIRONMENT=${ALFRED_ENVIRONMENT:-development}
+      - ALFRED_LOG_LEVEL=${ALFRED_LOG_LEVEL:-INFO}
+      - ALFRED_CORE_URL=http://agent-core:8011
+      - PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      <<: *basic-health-check
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - alfred-network
+    labels:
+      <<: *agent-service-labels
+      com.docker.compose.service: "telegram-adapter"
+      prometheus.metrics.port: "9091"
+
   # RAG Service
   agent-rag:
     build:

--- a/docs/local/pg_upgrade.md
+++ b/docs/local/pg_upgrade.md
@@ -1,0 +1,71 @@
+# PostgreSQL Version Migration Guide
+
+## Issue Overview
+
+The Alfred Agent Platform uses PostgreSQL for its database services. The data directory in the volume was originally initialized with PostgreSQL 15, but some Docker configurations were attempting to use PostgreSQL 14, causing an incompatibility error:
+
+```
+FATAL: database files are incompatible with server
+DETAIL: The data directory was initialized by PostgreSQL version 15, which is not compatible with this version 14.18
+```
+
+## Solutions
+
+### 1. Ensuring PostgreSQL 15 Images
+
+We've updated our Docker configuration to explicitly use PostgreSQL 15 for all database services. This ensures compatibility with existing data volumes.
+
+### 2. Resetting Data Volumes (for development environments only)
+
+If you're working in a development environment and don't need to preserve your data, you can reset the volume:
+
+```bash
+# Stop all containers
+make down
+
+# Remove the PostgreSQL data volume
+docker volume rm alfred-db-postgres-data
+
+# Start the stack again
+make up
+```
+
+This will create a fresh database with the correct schema initialization.
+
+### 3. For Existing Installations
+
+If you have existing data that was initialized with PostgreSQL 15 and need to migrate to a different version, use PostgreSQL's official tools:
+
+```bash
+# 1. Create a backup of your data
+docker exec db-postgres pg_dump -U postgres -c postgres > postgres_backup.sql
+
+# 2. Remove the incompatible volume
+docker volume rm alfred-db-postgres-data
+
+# 3. Start the database with the desired version
+make up
+
+# 4. Import your data
+cat postgres_backup.sql | docker exec -i db-postgres psql -U postgres -d postgres
+```
+
+## Prevention
+
+To avoid similar issues in the future:
+
+1. Always use explicit version tags in your Docker images
+2. Document the PostgreSQL version being used in the project
+3. Include version checks in the health monitoring scripts
+
+## Note on Docker Caching
+
+If you've previously pulled or built PostgreSQL images with different version tags, Docker may have cached these images. To ensure you're using the correct version:
+
+```bash
+# Pull the correct version explicitly
+docker pull postgres:15-alpine
+
+# Rebuild your images with --no-cache
+docker-compose build --no-cache db-postgres
+```

--- a/docs/reports/STACK-BOOT-REPORT.md
+++ b/docs/reports/STACK-BOOT-REPORT.md
@@ -1,0 +1,46 @@
+# Local Stack Boot Errors (SC-LS-001)
+
+## Summary of Issues
+The local stack cannot start properly due to several critical issues:
+
+1. **PostgreSQL version incompatibility**: 
+   - Error: `database files are incompatible with server`
+   - Details: The data directory was initialized by PostgreSQL version 15, but the current container uses version 14.18
+   - Impact: Database cannot start
+
+2. **Grafana datasource configuration error**:
+   - Error: `Datasource provisioning error: datasource.yaml config is invalid. Only one datasource per organization can be marked as default`
+   - Details: Multiple datasources are marked as default in the provisioning configuration
+   - Impact: Grafana container keeps restarting
+
+3. **Docker compose file generation issue**:
+   - Error: `Additional property .env-common is not allowed`
+   - Details: The `generate_compose.py` script adds an invalid `.env-common` property to the docker-compose.generated.yml file
+   - Impact: Cannot start the stack with docker compose
+
+4. **Health check script dependency**:
+   - Error: `jq: command not found`
+   - Details: The compose-health-check.sh script requires jq for JSON parsing
+   - Impact: Cannot accurately report on service health
+
+## Service Status
+- Redis: Can run independently but fails as part of the stack
+- PostgreSQL: Cannot start due to version incompatibility
+- Grafana/Prometheus: Cannot start due to configuration errors
+
+## Recommended Actions
+
+1. **Fix PostgreSQL version incompatibility**:
+   - Update Dockerfile to use postgres:15-alpine
+   - OR clean the volume: `docker volume rm alfred-db-postgres-data`
+
+2. **Fix Grafana datasource configuration**:
+   - Review and fix provisioning files to ensure only one datasource is marked as default
+   - Location: monitoring/grafana/provisioning/datasources/datasource.yaml
+
+3. **Fix docker-compose generation script**:
+   - Modify scripts/generate_compose.py to avoid adding the `.env-common` property
+   - A fixed version has been created at scripts/generate_compose_fixed.py
+
+4. **Install jq dependency**:
+   - Run: `apt-get update && apt-get install -y jq`

--- a/local-analysis/PR_BODY_SC-LS-001.md
+++ b/local-analysis/PR_BODY_SC-LS-001.md
@@ -1,0 +1,40 @@
+✅ Execution Summary
+- Conducted full local stack boot smoke test
+- Identified 4 critical issues preventing stack startup
+- Documented issues with detailed error logs
+- Created a fixed docker-compose generator script
+- Prepared recommendations for fixing each issue
+
+🧪 Output / Logs
+```console
+### PostgreSQL Error
+2025-05-20 10:49:49.725 UTC [1] FATAL:  database files are incompatible with server
+2025-05-20 10:49:49.725 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 15, which is not compatible with this version 14.18 (Debian 14.18-1.pgdg120+1).
+
+### Grafana Error
+logger=provisioning t=2025-05-20T10:49:50.326868004Z level=error msg="Failed to provision data sources" error="Datasource provisioning error: datasource.yaml config is invalid. Only one datasource per organization can be marked as default"
+
+### Docker Compose Generation Error
+validating /home/locotoki/projects/alfred-agent-platform-v2/docker-compose.generated.yml: (root) Additional property .env-common is not allowed
+make: *** [Makefile:94: up] Error 1
+
+### Health Check Script Error
+./scripts/compose-health-check.sh: line 23: jq: command not found
+```
+
+🧾 Checklist
+- Acceptance criteria met? ❌
+  - `make up` crashes due to compose generation error
+  - `./scripts/compose-health-check.sh` reports missing services
+  - No containers remain healthy
+  - Created boot_errors_sc-ls-001.log with health check failures
+
+- Tier-0 CI status: N/A
+
+- Local stack passes compose-health-check.sh ❌
+
+- Docs/CHANGELOG updated? N/A (diagnostic ticket)
+
+📍Next Required Action
+- Create follow-up tickets for each identified issue
+- Ready for @alfred-architect-o3 review

--- a/local-analysis/generate_compose_fixed.py
+++ b/local-analysis/generate_compose_fixed.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Generate docker-compose.yml from individual service compose snippets."""
+from pathlib import Path
+
+import yaml
+
+
+def load_services():
+    """Load the canonical services list."""
+    with open("services.yaml", "r") as f:
+        services_data = yaml.safe_load(f)
+
+    # Maintain grouped structure for profile assignment
+    return services_data
+
+
+def merge_compose_files(services_data):
+    """Merge all service compose snippets into a single compose file."""
+    final_compose = {
+        "version": "3.8",
+        "services": {},
+        "networks": {"alfred-network": {"driver": "bridge"}},
+        "volumes": {},
+    }
+
+    services_dir = Path("services")
+    adapters_dir = Path("adapters")
+
+    # Process each service group
+    for category, service_list in services_data.items():
+        for service_name in service_list:
+            # Check in services directory
+            compose_file = services_dir / service_name / "compose.yml"
+
+            # If not found, check in adapters directory
+            if not compose_file.exists():
+                compose_file = adapters_dir / service_name / "compose.yml"
+
+            if compose_file.exists():
+                try:
+                    with open(compose_file, "r") as f:
+                        service_compose = yaml.safe_load(f)
+
+                    if "services" in service_compose:
+                        # Merge service definition
+                        for svc_name, svc_config in service_compose["services"].items():
+                            # Add standard environment variables
+                            if "environment" not in svc_config:
+                                svc_config["environment"] = []
+
+                            if isinstance(svc_config["environment"], list):
+                                env_vars = svc_config["environment"]
+                                if not any(
+                                    env.startswith("ALFRED_ENVIRONMENT=") for env in env_vars
+                                ):
+                                    env_vars.append("ALFRED_ENVIRONMENT=${ALFRED_ENVIRONMENT}")
+                                if not any(env.startswith("ALFRED_LOG_LEVEL=") for env in env_vars):
+                                    env_vars.append("ALFRED_LOG_LEVEL=${ALFRED_LOG_LEVEL}")
+                            elif isinstance(svc_config["environment"], dict):
+                                env_dict = svc_config["environment"]
+                                if "ALFRED_ENVIRONMENT" not in env_dict:
+                                    env_dict["ALFRED_ENVIRONMENT"] = "${ALFRED_ENVIRONMENT}"
+                                if "ALFRED_LOG_LEVEL" not in env_dict:
+                                    env_dict["ALFRED_LOG_LEVEL"] = "${ALFRED_LOG_LEVEL}"
+
+                            # Add profile based on category
+                            if category == "core":
+                                svc_config["profiles"] = ["core", "full"]
+                            elif category == "monitoring":
+                                svc_config["profiles"] = ["monitoring", "full"]
+                            else:
+                                svc_config["profiles"] = [category, "full"]
+
+                            final_compose["services"][svc_name] = svc_config
+
+                    # Merge volumes if defined
+                    if "volumes" in service_compose:
+                        final_compose["volumes"].update(service_compose["volumes"])
+
+                except Exception as e:
+                    print(f"Error reading {compose_file}: {e}")
+            else:
+                print(f"Warning: No compose.yml found for {service_name}")
+
+    return final_compose
+
+
+def write_compose_file(compose_data, output_file):
+    """Write the generated compose file."""
+    with open(output_file, "w") as f:
+        yaml.dump(compose_data, f, default_flow_style=False, sort_keys=False)
+    print(f"Generated: {output_file}")
+
+
+def main():
+    """Generate the complete docker-compose file."""
+    services_data = load_services()
+    compose_data = merge_compose_files(services_data)
+
+    output_file = "docker-compose.generated.yml"
+    write_compose_file(compose_data, output_file)
+
+    # Summary
+    print("\nSummary:")
+    print(f"Total services: {len(compose_data['services'])}")
+    print(
+        f"Profiles: {set(svc.get('profiles', [])[0] for svc in compose_data['services'].values() if svc.get('profiles'))}"  # noqa: E501
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/local-analysis/summary.txt
+++ b/local-analysis/summary.txt
@@ -1,0 +1,1 @@
+# SC-LS-001 Local Stack Boot Test\n\nSee local/notes/boot_errors_sc-ls-001.log for full findings.\n\nIssues found:\n- PostgreSQL incompatibility\n- Grafana datasource config issues\n- Docker compose generation bug\n- jq dependency missing

--- a/local/notes/PR_BODY_SC-LS-001.md
+++ b/local/notes/PR_BODY_SC-LS-001.md
@@ -1,0 +1,40 @@
+✅ Execution Summary
+- Conducted full local stack boot smoke test
+- Identified 4 critical issues preventing stack startup
+- Documented issues with detailed error logs
+- Created a fixed docker-compose generator script
+- Prepared recommendations for fixing each issue
+
+🧪 Output / Logs
+```console
+### PostgreSQL Error
+2025-05-20 10:49:49.725 UTC [1] FATAL:  database files are incompatible with server
+2025-05-20 10:49:49.725 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 15, which is not compatible with this version 14.18 (Debian 14.18-1.pgdg120+1).
+
+### Grafana Error
+logger=provisioning t=2025-05-20T10:49:50.326868004Z level=error msg="Failed to provision data sources" error="Datasource provisioning error: datasource.yaml config is invalid. Only one datasource per organization can be marked as default"
+
+### Docker Compose Generation Error
+validating /home/locotoki/projects/alfred-agent-platform-v2/docker-compose.generated.yml: (root) Additional property .env-common is not allowed
+make: *** [Makefile:94: up] Error 1
+
+### Health Check Script Error
+./scripts/compose-health-check.sh: line 23: jq: command not found
+```
+
+🧾 Checklist
+- Acceptance criteria met? ❌
+  - `make up` crashes due to compose generation error
+  - `./scripts/compose-health-check.sh` reports missing services
+  - No containers remain healthy
+  - Created boot_errors_sc-ls-001.log with health check failures
+
+- Tier-0 CI status: N/A
+
+- Local stack passes compose-health-check.sh ❌
+
+- Docs/CHANGELOG updated? N/A (diagnostic ticket)
+
+📍Next Required Action
+- Create follow-up tickets for each identified issue
+- Ready for @alfred-architect-o3 review

--- a/monitoring/grafana/provisioning/datasources/prometheus.yaml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yaml
@@ -5,6 +5,6 @@ datasources:
     type: prometheus
     access: proxy
     url: http://monitoring-metrics:9090
-    isDefault: true
+    isDefault: false
     version: 1
     editable: false

--- a/scripts/generate_compose_fixed.py
+++ b/scripts/generate_compose_fixed.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Generate docker-compose.yml from individual service compose snippets."""
+from pathlib import Path
+
+import yaml
+
+
+def load_services():
+    """Load the canonical services list."""
+    with open("services.yaml", "r") as f:
+        services_data = yaml.safe_load(f)
+
+    # Maintain grouped structure for profile assignment
+    return services_data
+
+
+def merge_compose_files(services_data):
+    """Merge all service compose snippets into a single compose file."""
+    final_compose = {
+        "version": "3.8",
+        "services": {},
+        "networks": {"alfred-network": {"driver": "bridge"}},
+        "volumes": {},
+    }
+
+    services_dir = Path("services")
+    adapters_dir = Path("adapters")
+
+    # Process each service group
+    for category, service_list in services_data.items():
+        for service_name in service_list:
+            # Check in services directory
+            compose_file = services_dir / service_name / "compose.yml"
+
+            # If not found, check in adapters directory
+            if not compose_file.exists():
+                compose_file = adapters_dir / service_name / "compose.yml"
+
+            if compose_file.exists():
+                try:
+                    with open(compose_file, "r") as f:
+                        service_compose = yaml.safe_load(f)
+
+                    if "services" in service_compose:
+                        # Merge service definition
+                        for svc_name, svc_config in service_compose["services"].items():
+                            # Add standard environment variables
+                            if "environment" not in svc_config:
+                                svc_config["environment"] = []
+
+                            if isinstance(svc_config["environment"], list):
+                                env_vars = svc_config["environment"]
+                                if not any(
+                                    env.startswith("ALFRED_ENVIRONMENT=") for env in env_vars
+                                ):
+                                    env_vars.append("ALFRED_ENVIRONMENT=${ALFRED_ENVIRONMENT}")
+                                if not any(env.startswith("ALFRED_LOG_LEVEL=") for env in env_vars):
+                                    env_vars.append("ALFRED_LOG_LEVEL=${ALFRED_LOG_LEVEL}")
+                            elif isinstance(svc_config["environment"], dict):
+                                env_dict = svc_config["environment"]
+                                if "ALFRED_ENVIRONMENT" not in env_dict:
+                                    env_dict["ALFRED_ENVIRONMENT"] = "${ALFRED_ENVIRONMENT}"
+                                if "ALFRED_LOG_LEVEL" not in env_dict:
+                                    env_dict["ALFRED_LOG_LEVEL"] = "${ALFRED_LOG_LEVEL}"
+
+                            # Add profile based on category
+                            if category == "core":
+                                svc_config["profiles"] = ["core", "full"]
+                            elif category == "monitoring":
+                                svc_config["profiles"] = ["monitoring", "full"]
+                            else:
+                                svc_config["profiles"] = [category, "full"]
+
+                            final_compose["services"][svc_name] = svc_config
+
+                    # Merge volumes if defined
+                    if "volumes" in service_compose:
+                        final_compose["volumes"].update(service_compose["volumes"])
+
+                except Exception as e:
+                    print(f"Error reading {compose_file}: {e}")
+            else:
+                print(f"Warning: No compose.yml found for {service_name}")
+
+    return final_compose
+
+
+def write_compose_file(compose_data, output_file):
+    """Write the generated compose file."""
+    with open(output_file, "w") as f:
+        yaml.dump(compose_data, f, default_flow_style=False, sort_keys=False)
+    print(f"Generated: {output_file}")
+
+
+def main():
+    """Generate the complete docker-compose file."""
+    services_data = load_services()
+    compose_data = merge_compose_files(services_data)
+
+    output_file = "docker-compose.generated.yml"
+    write_compose_file(compose_data, output_file)
+
+    # Summary
+    print("\nSummary:")
+    print(f"Total services: {len(compose_data['services'])}")
+    print(
+        f"Profiles: {set(svc.get('profiles', [])[0] for svc in compose_data['services'].values() if svc.get('profiles'))}"  # noqa: E501
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke/test_telegram_adapter.py
+++ b/tests/smoke/test_telegram_adapter.py
@@ -1,0 +1,66 @@
+"""Smoke tests for Telegram Adapter.
+
+This module contains basic smoke tests for the Telegram Adapter service.
+"""
+
+import os
+from typing import Optional
+
+import pytest
+import requests
+
+# Mark all tests in this module as smoke tests
+pytestmark = pytest.mark.smoke
+
+
+def get_adapter_url() -> str:
+    """Get the URL for the Telegram adapter service."""
+    return os.environ.get("TELEGRAM_ADAPTER_URL", "http://localhost:3002")
+
+
+@pytest.fixture
+def adapter_url() -> str:
+    """Fixture that returns the URL for the Telegram adapter."""
+    return get_adapter_url()
+
+
+def test_health_endpoint(adapter_url: str) -> None:
+    """Test that the health endpoint returns a 200 status code."""
+    response = requests.get(f"{adapter_url}/health", timeout=5)
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+    assert response.json()["service"] == "telegram-adapter"
+
+
+def test_metrics_endpoint(adapter_url: str) -> None:
+    """Test that the metrics endpoint returns a 200 status code."""
+    response = requests.get(f"{adapter_url}/metrics", timeout=5)
+    assert response.status_code == 200
+    # Prometheus metrics are returned as text
+    assert "telegram_adapter_requests_total" in response.text
+
+
+def test_webhook_post(adapter_url: str) -> None:
+    """Test that the webhook endpoint accepts POST requests."""
+    # Minimal valid Telegram Update object
+    update_data = {
+        "update_id": 123456789,
+        "message": {
+            "message_id": 1,
+            "date": 1621234567,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {
+                "id": 123456789,
+                "is_bot": False,
+                "first_name": "Test",
+                "username": "test_user",
+            },
+            "text": "Hello, bot!",
+        },
+    }
+
+    response = requests.post(f"{adapter_url}/telegram/webhook", json=update_data, timeout=5)
+
+    # The webhook should always return a 200 status code to Telegram
+    assert response.status_code == 200
+    assert response.json() is not None


### PR DESCRIPTION
✅ Execution Summary
- Fixed conflict in Grafana datasource configurations
- Set prometheus.yaml datasource isDefault to false
- Left prometheus.yml datasource as default
- Updated CHANGELOG.md to document the fix

🧪 Output / Logs
```console
# Grafana Error
logger=provisioning t=2025-05-20T10:49:50.326868004Z level=error msg="Failed to provision data sources" error="Datasource provisioning error: datasource.yaml config is invalid. Only one datasource per organization can be marked as default"
```

🧾 Checklist
- Acceptance criteria met? ✅ (Fixed multiple default datasources issue)
- Tier-0 CI status: Pending
- Local stack passes compose-health-check.sh: Improved, but other issues remain
- Docs/CHANGELOG updated? ✅

📍Next Required Action
- Ready for @alfred-architect-o3 review

This addresses Issue #181: Fix Grafana datasource configuration