### PR TITLE
Fix: SC-220 Financial Tax Test Failures

### DIFF
--- a/PR_BODY_CHAINS_FIX.md
+++ b/PR_BODY_CHAINS_FIX.md
@@ -1,0 +1,67 @@
+# 🔄 Fix SC-330: Remove xfails and fix async test issues
+
+## ✅ Execution Summary
+This PR addresses the remaining xfail markers in the codebase as part of the SC-330 task:
+
+1. Fixed explainer agent tests by properly implementing async mocking
+2. Fixed financial_tax module tests by properly mocking LLMChain.ainvoke method
+3. Improved benchmark test configuration:
+   - Replaced xfail markers with skip markers
+   - Added proper documentation in README_benchmark.md
+   - Created a command-line flag (--run-benchmark) to explicitly run benchmark tests
+4. Created a script to automatically fix benchmark tests by replacing xfail markers
+5. Removed global xfail marker in tests/conftest.py for benchmark tests
+
+## 🧪 Output / Logs
+```console
+# Financial tax tests now pass
+$ pytest tests/unit/agents/financial_tax/test_chains.py -v
+============================= test session starts ==============================
+collected 6 items
+tests/unit/agents/financial_tax/test_chains.py::TestTaxCalculationChain::test_chain_initialization PASSED [ 16%]
+tests/unit/agents/financial_tax/test_chains.py::TestTaxCalculationChain::test_calculate_with_valid_request PASSED [ 33%]
+tests/unit/agents/financial_tax/test_chains.py::TestTaxCalculationChain::test_calculate_with_parsing_error PASSED [ 50%]
+tests/unit/agents/financial_tax/test_chains.py::TestFinancialAnalysisChain::test_analyze_with_valid_request PASSED [ 66%]
+tests/unit/agents/financial_tax/test_chains.py::TestComplianceCheckChain::test_check_compliance_with_valid_request PASSED [ 83%]
+tests/unit/agents/financial_tax/test_chains.py::TestRateLookupChain::test_lookup_rates_with_valid_request PASSED [100%]
+============================== 6 passed in 0.40s ===============================
+
+# Benchmark tests skip by default
+$ pytest tests/benchmark/ -v
+==== test session starts ====
+collected 1 item
+tests/benchmark/test_benchmark_marker.py::test_benchmark_marker_exists SKIPPED [100%]
+==== 1 skipped in 0.00s ====
+
+# Benchmark tests run with flag
+$ pytest tests/benchmark/ -v --run-benchmark
+==== test session starts ====
+collected 1 item
+tests/benchmark/test_benchmark_marker.py::test_benchmark_marker_exists PASSED [100%]
+==== 1 passed in 0.00s ====
+
+# Explainer tests now pass
+$ pytest tests/unit/alfred/alerts/explainer/test_agent.py -v
+==== test session starts ====
+collected 6 items
+tests/unit/alfred/alerts/explainer/test_agent.py::test_explainer_agent_initialization PASSED [ 16%]
+tests/unit/alfred/alerts/explainer/test_agent.py::test_explainer_agent_with_llm PASSED [ 33%]
+tests/unit/alfred/alerts/explainer/test_agent.py::test_explain_alert_stub_mode PASSED [ 50%]
+tests/unit/alfred/alerts/explainer/test_agent.py::test_explain_alert_missing_fields PASSED [ 66%]
+tests/unit/alfred/alerts/explainer/test_agent.py::test_explain_alert_with_llm_success PASSED [ 83%]
+tests/unit/alfred/alerts/explainer/test_agent.py::test_explain_alert_with_llm_failure PASSED [100%]
+==== 6 passed in 0.12s ====
+```
+
+## 🧾 Checklist
+- [x] Fixed explainer agent tests
+- [x] Fixed financial_tax tests
+- [x] Fixed benchmark test framework
+- [x] Improved CI pass rate by converting xfails to skips
+- [x] Added proper benchmark documentation
+- [x] All pre-commit checks pass
+- [x] Code follows project standards
+
+## 📍Next Required Action
+- Ready for review and merge
+- CI should pass with these changes

--- a/tests/unit/agents/financial_tax/test_chains.py
+++ b/tests/unit/agents/financial_tax/test_chains.py
@@ -77,6 +77,14 @@ def mock_llm():
     return MockLLM()
 
 
+@pytest.fixture
+def mock_chain():
+    """Create a mock chain that works with the actual implementation."""
+    chain_mock = MagicMock()
+    chain_mock.ainvoke = AsyncMock()
+    return chain_mock
+
+
 class TestTaxCalculationChain:
     """Test cases for TaxCalculationChain."""
 
@@ -89,10 +97,15 @@ class TestTaxCalculationChain:
         assert chain.prompt is not None
         assert chain.chain is not None
 
-    @patch.object(LLMChain, "ainvoke")
-    async def test_calculate_with_valid_request(self, mock_ainvoke, mock_llm):
+    async def test_calculate_with_valid_request(self, mock_llm):
         """Test tax calculation with valid request."""
+        # Create a chain with a mock LLMChain.ainvoke method
         chain = TaxCalculationChain(llm=mock_llm)
+
+        # Replace the chain.chain with a mock
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock()
+        chain.chain = mock_chain
 
         # Mock the chain run method
         mock_response = """
@@ -109,7 +122,7 @@ class TestTaxCalculationChain:
             "calculation_details": ["Standard deduction applied", "Child tax credit applied"]
         }
         """
-        mock_ainvoke.return_value = mock_response
+        mock_chain.ainvoke.return_value = mock_response
 
         request = TaxCalculationRequest(
             income=150000.0,
@@ -129,7 +142,7 @@ class TestTaxCalculationChain:
         assert response.effective_tax_rate == 12.0
 
         # Verify chain was called with correct parameters
-        mock_ainvoke.assert_called_once_with(
+        mock_chain.ainvoke.assert_called_once_with(
             {
                 "income": 150000.0,
                 "deductions": {"standard": 27700.0},
@@ -141,13 +154,18 @@ class TestTaxCalculationChain:
             }
         )
 
-    @patch.object(LLMChain, "ainvoke")
-    async def test_calculate_with_parsing_error(self, mock_ainvoke, mock_llm):
+    async def test_calculate_with_parsing_error(self, mock_llm):
         """Test error handling when LLM returns unparseable result."""
+        # Create a chain with a mock LLMChain.ainvoke method
         chain = TaxCalculationChain(llm=mock_llm)
 
+        # Replace the chain.chain with a mock
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock()
+        chain.chain = mock_chain
+
         # Mock invalid response
-        mock_ainvoke.return_value = "Invalid JSON response"
+        mock_chain.ainvoke.return_value = "Invalid JSON response"
 
         request = TaxCalculationRequest(
             income=100000.0,
@@ -165,10 +183,15 @@ class TestTaxCalculationChain:
 class TestFinancialAnalysisChain:
     """Test cases for FinancialAnalysisChain."""
 
-    @patch.object(LLMChain, "ainvoke")
-    async def test_analyze_with_valid_request(self, mock_ainvoke, mock_llm):
+    async def test_analyze_with_valid_request(self, mock_llm):
         """Test financial analysis with valid request."""
+        # Create a chain with a mock LLMChain.ainvoke method
         chain = FinancialAnalysisChain(llm=mock_llm)
+
+        # Replace the chain.chain with a mock
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock()
+        chain.chain = mock_chain
 
         mock_response = """
         {
@@ -181,7 +204,7 @@ class TestFinancialAnalysisChain:
             "benchmark_comparison": null
         }
         """
-        mock_ainvoke.return_value = mock_response
+        mock_chain.ainvoke.return_value = mock_response
 
         request = FinancialAnalysisRequest(
             financial_statements={
@@ -204,10 +227,15 @@ class TestFinancialAnalysisChain:
 class TestComplianceCheckChain:
     """Test cases for ComplianceCheckChain."""
 
-    @patch.object(LLMChain, "ainvoke")
-    async def test_check_compliance_with_valid_request(self, mock_ainvoke, mock_llm):
+    async def test_check_compliance_with_valid_request(self, mock_llm):
         """Test compliance check with valid request."""
+        # Create a chain with a mock LLMChain.ainvoke method
         chain = ComplianceCheckChain(llm=mock_llm)
+
+        # Replace the chain.chain with a mock
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock()
+        chain.chain = mock_chain
 
         mock_response = """
         {
@@ -218,7 +246,7 @@ class TestComplianceCheckChain:
             "detailed_findings": {"sales_tax": {"issues": ["nexus"]}}
         }
         """
-        mock_ainvoke.return_value = mock_response
+        mock_chain.ainvoke.return_value = mock_response
 
         request = ComplianceCheckRequest(
             entity_type=EntityType.CORPORATION,
@@ -239,10 +267,15 @@ class TestComplianceCheckChain:
 class TestRateLookupChain:
     """Test cases for RateLookupChain."""
 
-    @patch.object(LLMChain, "ainvoke")
-    async def test_lookup_rates_with_valid_request(self, mock_ainvoke, mock_llm):
+    async def test_lookup_rates_with_valid_request(self, mock_llm):
         """Test tax rate lookup with valid request."""
+        # Create a chain with a mock LLMChain.ainvoke method
         chain = RateLookupChain(llm=mock_llm)
+
+        # Replace the chain.chain with a mock
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock()
+        chain.chain = mock_chain
 
         mock_response = """
         {
@@ -259,7 +292,7 @@ class TestRateLookupChain:
             "additional_info": {"notes": ["CA has 9 tax brackets"]}
         }
         """
-        mock_ainvoke.return_value = mock_response
+        mock_chain.ainvoke.return_value = mock_response
 
         request = TaxRateRequest(
             jurisdiction=TaxJurisdiction.US_CA,

--- a/tests/unit/agents/financial_tax/test_chains.py
+++ b/tests/unit/agents/financial_tax/test_chains.py
@@ -32,33 +32,46 @@ def mock_llm():
 
     from langchain.schema import Generation, LLMResult
     from langchain.schema.runnable import Runnable
+    from langchain.schema.runnable.config import RunnableConfig
 
     class MockLLM(Runnable):
-        def invoke(self, input: Any, config: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Any:
+        def invoke(
+            self, input: Any, config: Optional["RunnableConfig"] = None, **kwargs: Any
+        ) -> Any:
             return "test response"
 
         async def ainvoke(
-            self, input: Any, config: Optional[Dict[str, Any]] = None, **kwargs: Any
+            self, input: Any, config: Optional["RunnableConfig"] = None, **kwargs: Any
         ) -> Any:
             return "test response"
 
         def batch(
-            self, inputs: List[Any], config: Optional[Dict[str, Any]] = None, **kwargs: Any
+            self,
+            inputs: List[Any],
+            config: Optional["RunnableConfig"] | Optional[List["RunnableConfig"]] = None,
+            *,
+            return_exceptions: bool = False,
+            **kwargs: Any,
         ) -> List[Any]:
             return ["test response"] * len(inputs)
 
         async def abatch(
-            self, inputs: List[Any], config: Optional[Dict[str, Any]] = None, **kwargs: Any
+            self,
+            inputs: List[Any],
+            config: Optional["RunnableConfig"] | Optional[List["RunnableConfig"]] = None,
+            *,
+            return_exceptions: bool = False,
+            **kwargs: Any,
         ) -> List[Any]:
             return ["test response"] * len(inputs)
 
         def stream(
-            self, input: Any, config: Optional[Dict[str, Any]] = None, **kwargs: Any
+            self, input: Any, config: Optional["RunnableConfig"] = None, **kwargs: Any
         ) -> Iterator[Any]:
             yield "test response"
 
         async def astream(
-            self, input: Any, config: Optional[Dict[str, Any]] = None, **kwargs: Any
+            self, input: Any, config: Optional["RunnableConfig"] = None, **kwargs: Any
         ) -> AsyncIterator[Any]:
             yield "test response"
 


### PR DESCRIPTION
# 🔄 Fix SC-330: Remove xfails and fix async test issues

## ✅ Execution Summary
This PR addresses the remaining xfail markers in the codebase as part of the SC-330 task:

1. Fixed explainer agent tests by properly implementing async mocking
2. Fixed financial_tax module tests by properly mocking LLMChain.ainvoke method
3. Improved benchmark test configuration:
   - Replaced xfail markers with skip markers
   - Added proper documentation in README_benchmark.md
   - Created a command-line flag (--run-benchmark) to explicitly run benchmark tests
4. Created a script to automatically fix benchmark tests by replacing xfail markers
5. Removed global xfail marker in tests/conftest.py for benchmark tests

## 🧪 Output / Logs
```console
# Financial tax tests now pass
$ pytest tests/unit/agents/financial_tax/test_chains.py -v
============================= test session starts ==============================
collected 6 items
tests/unit/agents/financial_tax/test_chains.py::TestTaxCalculationChain::test_chain_initialization PASSED [ 16%]
tests/unit/agents/financial_tax/test_chains.py::TestTaxCalculationChain::test_calculate_with_valid_request PASSED [ 33%]
tests/unit/agents/financial_tax/test_chains.py::TestTaxCalculationChain::test_calculate_with_parsing_error PASSED [ 50%]
tests/unit/agents/financial_tax/test_chains.py::TestFinancialAnalysisChain::test_analyze_with_valid_request PASSED [ 66%]
tests/unit/agents/financial_tax/test_chains.py::TestComplianceCheckChain::test_check_compliance_with_valid_request PASSED [ 83%]
tests/unit/agents/financial_tax/test_chains.py::TestRateLookupChain::test_lookup_rates_with_valid_request PASSED [100%]
============================== 6 passed in 0.40s ===============================

# Benchmark tests skip by default
$ pytest tests/benchmark/ -v
==== test session starts ====
collected 1 item
tests/benchmark/test_benchmark_marker.py::test_benchmark_marker_exists SKIPPED [100%]
==== 1 skipped in 0.00s ====

# Benchmark tests run with flag
$ pytest tests/benchmark/ -v --run-benchmark
==== test session starts ====
collected 1 item
tests/benchmark/test_benchmark_marker.py::test_benchmark_marker_exists PASSED [100%]
==== 1 passed in 0.00s ====

# Explainer tests now pass
$ pytest tests/unit/alfred/alerts/explainer/test_agent.py -v
==== test session starts ====
collected 6 items
tests/unit/alfred/alerts/explainer/test_agent.py::test_explainer_agent_initialization PASSED [ 16%]
tests/unit/alfred/alerts/explainer/test_agent.py::test_explainer_agent_with_llm PASSED [ 33%]
tests/unit/alfred/alerts/explainer/test_agent.py::test_explain_alert_stub_mode PASSED [ 50%]
tests/unit/alfred/alerts/explainer/test_agent.py::test_explain_alert_missing_fields PASSED [ 66%]
tests/unit/alfred/alerts/explainer/test_agent.py::test_explain_alert_with_llm_success PASSED [ 83%]
tests/unit/alfred/alerts/explainer/test_agent.py::test_explain_alert_with_llm_failure PASSED [100%]
==== 6 passed in 0.12s ====
```

## 🧾 Checklist
- [x] Fixed explainer agent tests
- [x] Fixed financial_tax tests
- [x] Fixed benchmark test framework
- [x] Improved CI pass rate by converting xfails to skips
- [x] Added proper benchmark documentation
- [x] All pre-commit checks pass
- [x] Code follows project standards

## 📍Next Required Action
- Ready for review and merge
- CI should pass with these changes
