### PR TITLE
ci: improve update-status workflow reliability and features

### DIFF
--- a/.github/workflows/update-status.yml
+++ b/.github/workflows/update-status.yml
@@ -1,6 +1,7 @@
 name: Update Consolidation Progress Beacon
 
 on:
+  workflow_dispatch:  # Allow manual triggering
   push:
     branches:
       - ops/SC-241-agent-consolidation
@@ -11,10 +12,16 @@ on:
     types:
       - completed
 
+permissions:
+  contents: write   # Required for pushing changes
+  pull-requests: read
+  issues: read      # Required for reading issues
+
 jobs:
   update-status:
     runs-on: ubuntu-latest
     if: |
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/ops/SC-241-agent-consolidation') ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
 
@@ -33,11 +40,9 @@ jobs:
 
       - name: Install GitHub CLI
         run: |
-          # Make sure we have the latest version
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-          sudo apt-add-repository https://cli.github.com/packages
-          sudo apt update
-          sudo apt install gh
+          # Direct download instead of using apt repository (more reliable across Ubuntu versions)
+          curl -fsSL https://github.com/cli/cli/releases/download/v2.44.1/gh_2.44.1_linux_amd64.tar.gz | sudo tar xz -C /usr/local --strip-components=1
+          gh --version
 
       - name: Authenticate GitHub CLI
         run: |


### PR DESCRIPTION
✅ Execution Summary

* Improved workflow reliability by using direct GitHub CLI download instead of apt repository
* Added workflow_dispatch event to enable manual workflow triggering
* Added proper permissions configuration for GitHub token
* Updated workflow condition to support manual trigger

🧪 Output / Logs
```console
$ git diff .github/workflows/update-status.yml
+on:
+  workflow_dispatch:  # Allow manual triggering
+permissions:
+  contents: write   # Required for pushing changes
+  pull-requests: read
+  issues: read      # Required for reading issues
+    if: |
+      github.event_name == 'workflow_dispatch' ||
-      # Make sure we have the latest version
-      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-      sudo apt-add-repository https://cli.github.com/packages
-      sudo apt update
-      sudo apt install gh
+      # Direct download instead of using apt repository (more reliable across Ubuntu versions)
+      curl -fsSL https://github.com/cli/cli/releases/download/v2.44.1/gh_2.44.1_linux_amd64.tar.gz | sudo tar xz -C /usr/local --strip-components=1
+      gh --version
```

🧾 Checklist
- Fixed GitHub CLI installation ✅
- Added workflow_dispatch trigger ✅
- Added proper permissions ✅
- Pre-commit checks pass ✅

📍Next Required Action
- Ready for @alfred-architect-o3 review

Note: The auto-merge feature for branches should be enabled via the GitHub web UI as it requires specific UI interactions.