### PR TITLE
hotfix: fix JSON format parsing in board sync

### DIFF
--- a/workflow/cli/board_sync.sh
+++ b/workflow/cli/board_sync.sh
@@ -222,6 +222,11 @@ find_project() {
         exit 1
     fi
 
+    # Extract projects array if wrapped in {"projects": [...]} format
+    if echo "$projects_json" | jq -e '.projects' >/dev/null 2>&1; then
+        projects_json=$(echo "$projects_json" | jq '.projects')
+    fi
+
     # Debug: show the actual JSON structure
     if [[ "$VERBOSE" == "true" ]]; then
         log_debug "Projects JSON structure:"


### PR DESCRIPTION
Quick fix for board sync JSON parsing issue.

The `gh project list --format json` returns wrapped format: `{"projects": [...]}` but the script expected direct array.

This fix:
- Extracts the .projects array from wrapped JSON
- Fixes 'No projects found' error when projects actually exist
- Enables board sync to find 'Alfred-core Sprint Board' correctly