### PR TITLE
Hot-fix: make CI green for SC-241

### DIFF
--- a/services/agent_bizops/requirements.txt
+++ b/services/agent_bizops/requirements.txt
@@ -3,4 +3,4 @@ uvicorn[standard]>=0.24.0
 pydantic>=2.5.0
 httpx>=0.25.0
 structlog>=23.2.0
-prometheus-client==0.20.0
+prometheus-client==0.19.0


### PR DESCRIPTION
Fix prometheus-client version mismatch (0.20.0 → 0.19.0) to resolve CI failures