### PR TITLE
test: licence-gate red check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Alfred Team <team@alfred.ai>"]
 [tool.poetry.dependencies]
 python = "^3.11"
 urllib3 = "^2.0.7"
+PyQt5 = "^5.15.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = ["Alfred Team <team@alfred.ai>"]
 [tool.poetry.dependencies]
 python = "^3.11"
 urllib3 = "^2.0.7"
-PyQt5 = "^5.15.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,6 @@ redis==5.0.1
 httpx==0.26.0
 tenacity==8.2.3
 structlog==24.1.0
+
+# Test GPL dependency
+PyQt5==5.15.10


### PR DESCRIPTION
Testing licence-gate panel validation - adding PyQt5 (GPL license) to trigger red state.

This PR should:
1. Fail CI licence-gate check
2. Turn Grafana Tech-Debt panel red (1 violation)

Will be cleaned up immediately after validation.