### PR TITLE
fix: board-sync PAT scope handling

### DIFF
--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -1,5 +1,17 @@
 name: Board Sync Automation
 
+# README: Required Secret Configuration
+# This workflow requires a GitHub Personal Access Token (PAT) with the following scopes:
+# - repo (full control of private repositories)
+# - project (full control of classic projects)
+# - workflow (update GitHub Action workflows)
+#
+# To configure:
+# 1. Create a PAT at https://github.com/settings/tokens/new
+# 2. Select the required scopes listed above
+# 3. Add the token as a repository secret named BOARD_SYNC_PAT
+# 4. Go to Settings > Secrets and variables > Actions > New repository secret
+
 on:
   workflow_run:
     workflows: ["CI"]
@@ -38,7 +50,7 @@ jobs:
 
       - name: Authenticate GitHub CLI
         run: |
-          echo "${{ secrets.GH_AUTOMATION_PAT || secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+          echo "${{ secrets.BOARD_SYNC_PAT || secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
       - name: Extract issue number from PR (for workflow_run)
         if: github.event_name == 'workflow_run'


### PR DESCRIPTION
Fixes #295 - Add proper PAT scope detection and guidance

## Changes
- Add 403 error detection in board_sync.sh with clear PAT configuration steps
- Update board-sync.yml workflow to use BOARD_SYNC_PAT secret
- Add comprehensive documentation for required token scopes

## Required Action
Maintainers need to create and configure BOARD_SYNC_PAT secret with scopes: repo, project, workflow