### PR TITLE
feat(dx): add cold-start bench + CI stub

### DIFF
--- a/.github/workflows/cold-start-benchmark.yml
+++ b/.github/workflows/cold-start-benchmark.yml
@@ -1,0 +1,17 @@
+name: cold-start-benchmark
+on: [pull_request]
+jobs:
+  bench:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install hyperfine
+        run: sudo apt-get update && sudo apt-get install -y hyperfine jq
+      - name: Run cold-start benchmark (info only)
+        run: |
+          ./bench/cold_start.sh
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: cold_start
+          path: bench/cold_start.json

--- a/.github/workflows/nightly-images.yml
+++ b/.github/workflows/nightly-images.yml
@@ -1,0 +1,14 @@
+# Uncomment the "on:" block when you're ready to push nightly images
+# on:
+#   schedule:
+#     - cron:  '0 2 * * *'
+#   workflow_dispatch:
+name: nightly-images
+jobs:
+  build-push:
+    if: false   # flip to true when you uncomment the trigger
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build & push images
+        run: echo "🔧 build steps go here"

--- a/bench/cold_start.sh
+++ b/bench/cold_start.sh
@@ -1,0 +1,7 @@
+#\!/usr/bin/env bash
+set -euo pipefail
+RESULTS="bench/cold_start.json"
+
+echo "⏱️  Measuring cold start…"
+hyperfine --warmup 1 --export-json "$RESULTS" 'docker compose down -v >/dev/null 2>&1 || true && time alfred up'
+jq '.results[0].mean' "$RESULTS"  < /dev/null |  awk '{printf "⏱️  mean cold-start: %.2f s\n",$1}'

--- a/docs/dx/fast-loop.md
+++ b/docs/dx/fast-loop.md
@@ -1,0 +1,11 @@
+# DX Fast-Loop Sprint
+
+## 1 Setup
+
+## 2 Measure Cold-Start
+
+## 3 Optimise Docker & Compose
+
+## 4 CI Guard
+
+## 5 Nightly Pre-built Images

--- a/metrics/scripts_inventory.csv
+++ b/metrics/scripts_inventory.csv
@@ -109,6 +109,7 @@ backend/alfred/ml/alert_dataset.py,.py,8430,UNKNOWN
 backend/alfred/ml/faiss_index.py,.py,15057,UNKNOWN
 backend/alfred/ml/model_registry.py,.py,12232,UNKNOWN
 backend/alfred/ml/retrain_pipeline.py,.py,10853,UNKNOWN
+bench/cold_start.sh,.sh,327,UNKNOWN
 clean-youtube-service.ts,.ts,16421,UNKNOWN
 create-niche-scout-results.js,.js,2574,UNKNOWN
 diagnostics/rca/app.py,.py,5832,UNKNOWN
@@ -200,7 +201,6 @@ scripts/canary-monitor.sh,.sh,6322,UNKNOWN
 scripts/check-branch-protection.sh,.sh,2098,UNKNOWN
 scripts/check-ci-pr.sh,.sh,524,UNKNOWN
 scripts/ci_vuln_gate.py,.py,6633,UNKNOWN
-scripts/claude-screenshot.sh,.sh,3303,UNKNOWN
 scripts/cleanup-ci-files.sh,.sh,1046,UNKNOWN
 scripts/cleanup-docker-compose.sh,.sh,5968,UNKNOWN
 scripts/cleanup-inactive-compose-files.sh,.sh,3487,UNKNOWN
@@ -301,7 +301,6 @@ scripts/run_quick_health_check.sh,.sh,765,UNKNOWN
 scripts/run_synthetic_load.sh,.sh,890,UNKNOWN
 scripts/safe-sync.sh,.sh,5190,UNKNOWN
 scripts/scaffold_compose_snippets.py,.py,3055,UNKNOWN
-scripts/screenshot.py,.py,4999,UNKNOWN
 scripts/setup-db-metrics.sh,.sh,4089,UNKNOWN
 scripts/setup-deployment-tools.sh,.sh,1870,UNKNOWN
 scripts/skip-ci-for-cleanup.sh,.sh,478,UNKNOWN
@@ -317,10 +316,6 @@ scripts/standardize-service-health.sh,.sh,4456,UNKNOWN
 scripts/start-all-dev.sh,.sh,2809,UNKNOWN
 scripts/tag-healthcheck-release.sh,.sh,951,UNKNOWN
 scripts/tag-release.sh,.sh,552,UNKNOWN
-<<<<<<< HEAD
-=======
-scripts/take-screenshot.js,.js,3014,UNKNOWN
->>>>>>> 619b0a3e (feat(observability): GA panels only - p95 latency, error-rate & alert)
 scripts/test_dashboards.py,.py,6879,UNKNOWN
 scripts/update-alert-labels.py,.py,3120,UNKNOWN
 scripts/update-ci-command.sh,.sh,912,UNKNOWN


### PR DESCRIPTION
## ✅ Execution Summary
- Added bench/cold_start.sh script using hyperfine to measure alfred up cold start time
- Added cold-start-benchmark.yml CI workflow (non-blocking) to track metrics on PRs
- Added nightly-images.yml workflow scaffold (commented out for later activation)
- Added docs/dx/fast-loop.md outline for sprint documentation

## 🧪 Output / Logs
\\\

## 🧾 Checklist
- [x] Added cold-start benchmark script
- [x] Added CI workflow (non-blocking)
- [x] Added nightly images workflow template
- [x] Added documentation outline

## 📍 Next Required Action
- Run \ locally to capture baseline metric
- Start optimization work on Dockerfiles and compose files

Closes #316, #317

Part of DX Fast-Loop Sprint #315