### PR TITLE
docs: create Decision Log and record mock perf gate for v0.9.5

### DIFF
--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -1,0 +1,5 @@
+# Decision Log
+
+ < /dev/null |  Date (UTC) | Decision | Reference |
+| ---------- | -------- | --------- |
+| 2025-05-23 | Mock perf gate cleared; tag v0.9.5 | GH-run-15220732092 |


### PR DESCRIPTION
Create the Decision Log file and add entry for the mock performance gate that passed with p95=212.22ms and error=0.83%.