### PR TITLE
fix: correct cold-start workflow syntax error

### DIFF
--- a/.github/workflows/cold-start.yml
+++ b/.github/workflows/cold-start.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Compose
-        run:  < /dev/null |
+        run: |
           sudo apt-get update
           sudo apt-get install -y jq
       - name: Measure cold-start


### PR DESCRIPTION
Fixes the apt-get command syntax in cold-start.yml workflow that was causing CI failures.