### PR TITLE
feat: citation assembler & answer formatter skeleton

### DIFF
--- a/agent_core/answer/__init__.py
+++ b/agent_core/answer/__init__.py
@@ -1,0 +1,1 @@
+"""Answer formatting and citation assembly."""

--- a/agent_core/answer/formatter.py
+++ b/agent_core/answer/formatter.py
@@ -1,0 +1,33 @@
+"""Citation Assembler & Answer Formatter.
+
+Takes (query, retrieved_passages) and returns a dict:
+
+{
+  "answer": "<LLM-generated answer>",
+  "citations": [
+      {"id": <chunk_id>, "snippet": "...", "score": 0.89}
+  ]
+}
+
+Current stub echoes the top-k passages; GPT call will be
+added after ADR-013 is accepted.
+"""
+
+from __future__ import annotations
+from typing import Dict, List
+
+
+def assemble_answer(query: str, passages: List[Dict]) -> Dict:
+    """Return assembled answer with citations.
+
+    Very first placeholder that returns the first passage as 'answer'
+    and passes through citations unchanged.
+    """
+    if not passages:
+        return {"answer": "No information available.", "citations": []}
+
+    best = passages[0]
+    return {
+        "answer": best.get("snippet", "…"),
+        "citations": passages[:5],  # TODO: score filter & dedupe
+    }

--- a/metrics/scripts_inventory.csv
+++ b/metrics/scripts_inventory.csv
@@ -5,6 +5,8 @@ adapters/telegram/app.py,.py,6237,UNKNOWN
 adapters/telegram/start.sh,.sh,222,UNKNOWN
 agent-bizdev/health.sh,.sh,26,UNKNOWN
 agent_core/__init__.py,.py,26,UNKNOWN
+agent_core/answer/__init__.py,.py,47,UNKNOWN
+agent_core/answer/formatter.py,.py,863,UNKNOWN
 agent_core/db/__init__.py,.py,46,UNKNOWN
 agent_core/db/models.py,.py,725,UNKNOWN
 agent_core/db/session.py,.py,520,UNKNOWN
@@ -184,7 +186,7 @@ libs/observability/metrics.py,.py,5629,UNKNOWN
 libs/observability/tracing.py,.py,3684,UNKNOWN
 local-analysis/generate_compose_fixed.py,.py,4545,UNKNOWN
 metrics_fix.py,.py,875,UNKNOWN
-migrations/env.py,.py,2213,UNKNOWN
+migrations/env.py,.py,2191,UNKNOWN
 mission-control/src/index.js,.js,1098,UNKNOWN
 mission-control/src/streamlit_app.py,.py,5770,UNKNOWN
 monitoring/scripts/docker_stats.py,.py,0,UNKNOWN
@@ -599,6 +601,7 @@ tests/alfred/ml/test_thresholds.py,.py,9077,UNKNOWN
 tests/alfred/slack/__init__.py,.py,37,UNKNOWN
 tests/alfred/tools/test_formatter.py,.py,2610,UNKNOWN
 tests/alfred/utils/test_string_utils.py,.py,1962,UNKNOWN
+tests/answer/test_formatter.py,.py,399,UNKNOWN
 tests/backend/ml/__init__.py,.py,16,UNKNOWN
 tests/backend/ml/conftest.py,.py,2034,UNKNOWN
 tests/backend/ml/test_alert_dataset.py,.py,805,UNKNOWN
@@ -611,7 +614,7 @@ tests/backend/ml/test_trainer_benchmark.py,.py,2366,UNKNOWN
 tests/benchmark/conftest.py,.py,1281,UNKNOWN
 tests/benchmark/test_benchmark_marker.py,.py,712,UNKNOWN
 tests/conftest.py,.py,5218,UNKNOWN
-tests/db/test_connection.py,.py,183,UNKNOWN
+tests/db/test_connection.py,.py,184,UNKNOWN
 tests/e2e/__init__.py,.py,48,UNKNOWN
 tests/e2e/run-tests.sh,.sh,4889,UNKNOWN
 tests/e2e/test_review_contract.py,.py,1002,UNKNOWN

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,9 +1,7 @@
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
-
 from alembic import context
+from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -79,4 +77,5 @@ else:
 
 # Import models for autogenerate
 from agent_core.db import models
+
 target_metadata = models.SQLModel.metadata

--- a/tests/answer/test_formatter.py
+++ b/tests/answer/test_formatter.py
@@ -1,0 +1,11 @@
+from agent_core.answer.formatter import assemble_answer
+
+
+def test_assemble_basic():
+    passages = [
+        {"id": 1, "snippet": "Paris is the capital of France.", "score": 0.9},
+        {"id": 2, "snippet": "France is in Europe.", "score": 0.8},
+    ]
+    out = assemble_answer("What is the capital of France?", passages)
+    assert "Paris" in out["answer"]
+    assert len(out["citations"]) == 2

--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -1,5 +1,6 @@
-from agent_core.db.session import engine
 from sqlalchemy import inspect
+
+from agent_core.db.session import engine
 
 
 def test_tables_present():


### PR DESCRIPTION
Adds stub implementation for assembling LLM answers with citations (Agent-Core MVP · Epic #388).

* \ returns dummy answer using top passage.
* Unit test validates structure.
