### PR TITLE
CI: BizDev skip flag & Helm lint exclusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+    inputs:
+      skip_bizdev:
+        description: 'Skip BizDev tests'
+        required: false
+        type: boolean
+        default: false
 
 env:
   PYTHON_VERSION: "3.11"
@@ -190,6 +196,7 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
           PUBSUB_EMULATOR_HOST: localhost:8085
+          BIZDEV_SKIP: ${{ inputs.skip_bizdev || false }}
 
       - name: Run alert dispatcher tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-yaml
+        exclude: ^charts/alfred/templates/
       - id: check-json
       - id: end-of-file-fixer
       - id: trailing-whitespace


### PR DESCRIPTION
Adds **BIZDEV_SKIP** flag to bypass BizDev test suite until mature.
Excludes Helm templates from pre-commit lint to unblock PRs.