### PR TITLE
chore(board): record BizDev Backlog board-sync execution (simulation)

### DIFF
--- a/.docs/board-sync-run-20250524142106.txt
+++ b/.docs/board-sync-run-20250524142106.txt
@@ -1,0 +1,1 @@
+Board sync simulation executed on Sat May 24 13:21:06 UTC 2025

--- a/.docs/board-sync-simulation.sh
+++ b/.docs/board-sync-simulation.sh
@@ -1,0 +1,16 @@
+#\!/bin/bash
+# Board sync simulation - requires GH_TOKEN with project scope
+
+echo "=== Board Sync Simulation ==="
+echo "Would execute GraphQL mutations to:"
+echo "1. Add 'BizDev Backlog' status to project"
+echo "2. Move epics #398-#402 to BizDev Backlog column"
+echo ""
+echo "Required environment:"
+echo "- GH_TOKEN: ${GH_TOKEN:-(not set - needs PAT with project scope)}"
+echo "- PROJECT_ID: ${PROJECT_ID:-PVT_kwHOAWDeVs4A5ubE}"
+echo ""
+echo "To run actual sync:"
+echo "1. Create PAT at https://github.com/settings/tokens with 'project' scope"
+echo "2. export GH_TOKEN='ghp_your_token_here'"
+echo "3. Run: bash ./.docs/graphql-script-ready.sh"

--- a/metrics/scripts_inventory.csv
+++ b/metrics/scripts_inventory.csv
@@ -1,4 +1,5 @@
 path,ext,size_bytes,status
+.docs/board-sync-simulation.sh,.sh,644,UNKNOWN
 .github/workflow_helpers/build-size.sh,.sh,176,UNKNOWN
 adapters/telegram/__init__.py,.py,52,UNKNOWN
 adapters/telegram/app.py,.py,6237,UNKNOWN


### PR DESCRIPTION
Runs simulation of **graphql-script-ready.sh** to document the process for adding the 'BizDev Backlog' status and moving Epics #398-#402.

## ✅ What this PR does
- Adds board sync simulation script showing required PAT configuration
- Creates marker file for traceability
- Documents the manual steps needed without PAT

## 📍 Next Steps
To execute actual board sync:
1. Create PAT at https://github.com/settings/tokens with 'project' scope
2. Export: `export GH_TOKEN='ghp_your_token_here'`
3. Run: `bash ./.docs/graphql-script-ready.sh`

Or manually via GitHub UI:
1. Go to GA v3.0.0 Checklist project settings
2. Add 'BizDev Backlog' as a Status option
3. Move epics #398-#402 to the new column