### PR TITLE
feat: scaffold contact-ingest service (Epic #398)

### DIFF
--- a/.github/workflows/contact-ingest.yml
+++ b/.github/workflows/contact-ingest.yml
@@ -1,0 +1,30 @@
+name: contact-ingest image
+
+on:
+  push:
+    paths:
+      - 'services/contact-ingest/**'
+      - '.github/workflows/contact-ingest.yml'
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./services/contact-ingest
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/contact-ingest:latest

--- a/charts/alfred/values.yaml
+++ b/charts/alfred/values.yaml
@@ -19,3 +19,22 @@ hubspotMock:
     limits:
       memory: "256Mi"
       cpu: "200m"
+
+contactIngest:
+  enabled: false
+  image:
+    repository: ghcr.io/locotoki/contact-ingest
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 8080
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1188,6 +1188,30 @@ services:
       <<: *common-labels
       com.docker.compose.service: "hubspot-mock"
 
+  # Contact Ingest Service - Lead capture and processing
+  contact-ingest:
+    build:
+      context: ./services/contact-ingest
+      dockerfile: Dockerfile
+    image: ghcr.io/locotoki/contact-ingest:latest
+    container_name: contact-ingest
+    ports:
+      - "8082:8080"
+    environment:
+      - PORT=8080
+      - HUBSPOT_URL=http://hubspot-mock:8095
+    depends_on:
+      - hubspot-mock
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/docs"]
+      <<: *basic-health-check
+    restart: unless-stopped
+    networks:
+      - alfred-network
+    labels:
+      <<: *common-labels
+      com.docker.compose.service: "contact-ingest"
+
 # Volumes
 volumes:
   # Infrastructure volumes

--- a/metrics/scripts_inventory.csv
+++ b/metrics/scripts_inventory.csv
@@ -434,6 +434,9 @@ services/alfred-core/entrypoint.sh,.sh,1219,UNKNOWN
 services/alfred-core/healthcheck.sh,.sh,387,UNKNOWN
 services/atlas-worker/atlas/__init__.py,.py,23,UNKNOWN
 services/atlas-worker/atlas/main.py,.py,819,UNKNOWN
+services/contact-ingest/src/__init__.py,.py,30,UNKNOWN
+services/contact-ingest/src/__main__.py,.py,167,UNKNOWN
+services/contact-ingest/src/contact_ingest.py,.py,502,UNKNOWN
 services/db-storage/bypass-migrations.js,.js,808,UNKNOWN
 services/db-storage/entrypoint.sh,.sh,1614,UNKNOWN
 services/db-storage/fix-migrations-entrypoint.sh,.sh,2052,UNKNOWN

--- a/services/contact-ingest/Dockerfile
+++ b/services/contact-ingest/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY src/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src .
+CMD ["python", "-m", "contact_ingest"]

--- a/services/contact-ingest/src/__init__.py
+++ b/services/contact-ingest/src/__init__.py
@@ -1,0 +1,1 @@
+"""Contact Ingest Service."""

--- a/services/contact-ingest/src/__main__.py
+++ b/services/contact-ingest/src/__main__.py
@@ -1,0 +1,8 @@
+"""Contact Ingest Service entry point."""
+
+import uvicorn
+
+from .contact_ingest import app
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/services/contact-ingest/src/contact_ingest.py
+++ b/services/contact-ingest/src/contact_ingest.py
@@ -1,0 +1,21 @@
+"""Contact Ingest Service API."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Contact-Ingest", version="0.1.0")
+
+
+class Contact(BaseModel):
+    """Contact model for lead capture."""
+
+    email: str
+    first_name: str | None = None
+    last_name: str | None = None
+
+
+@app.post("/ingest")
+async def ingest(contact: Contact):
+    """Accept contact for processing."""
+    # TODO: forward to hubspot-mock or queue
+    return {"status": "accepted", "contact": contact}

--- a/services/contact-ingest/src/requirements.txt
+++ b/services/contact-ingest/src/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+pydantic==2.8.1
+httpx==0.27.0


### PR DESCRIPTION
Creates the **contact-ingest** FastAPI stub, sets up GHCR image build, and wires it into Compose & Helm.

## What this PR does
- Scaffolds contact-ingest FastAPI service
- Adds Docker configuration and GHCR pipeline
- Integrates with docker-compose.yml
- Adds Helm chart values

## Related
- Epic #398: BizDev MVP