### PR TITLE
fix(test): use Docker Compose V2 CLI syntax

### DIFF
--- a/metrics/scripts_inventory.csv
+++ b/metrics/scripts_inventory.csv
@@ -621,7 +621,7 @@ tests/backend/ml/test_retrain_pipeline.py,.py,1436,UNKNOWN
 tests/backend/ml/test_trainer_benchmark.py,.py,2366,UNKNOWN
 tests/benchmark/conftest.py,.py,1281,UNKNOWN
 tests/benchmark/test_benchmark_marker.py,.py,712,UNKNOWN
-tests/bizdev/test_roundtrip.py,.py,1055,UNKNOWN
+tests/bizdev/test_roundtrip.py,.py,1075,UNKNOWN
 tests/conftest.py,.py,5218,UNKNOWN
 tests/db/test_connection.py,.py,184,UNKNOWN
 tests/e2e/__init__.py,.py,48,UNKNOWN

--- a/tests/bizdev/requirements.txt
+++ b/tests/bizdev/requirements.txt
@@ -1,3 +1,2 @@
 pytest==8.2.0
 requests==2.32.2
-docker-compose>=1.29

--- a/tests/bizdev/test_roundtrip.py
+++ b/tests/bizdev/test_roundtrip.py
@@ -17,12 +17,14 @@ def _stack_up():
     import tempfile
 
     proc = subprocess.Popen(
-        ["docker-compose", "-f", COMPOSE_FILE, "up", "-d"],
+        ["docker", "compose", "-f", COMPOSE_FILE, "up", "-d"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
     proc.wait()
-    atexit.register(lambda: subprocess.call(["docker-compose", "-f", COMPOSE_FILE, "down", "-v"]))
+    atexit.register(
+        lambda: subprocess.call(["docker", "compose", "-f", COMPOSE_FILE, "down", "-v"])
+    )
     time.sleep(10)  # allow services to warm
     yield
 


### PR DESCRIPTION
## Summary
- Remove docker-compose Python package dependency that was failing to build
- Update subprocess calls to use 'docker compose' instead of 'docker-compose'
- Resolves PyYAML build failure in CI for BizDev eval harness

## Test Plan
- BizDev eval workflow will now install successfully
- Docker Compose V2 is available by default in GitHub Actions runners

🤖 Generated with [Claude Code](https://claude.ai/code)