### PR TITLE
fix(ci): run BizDev tests from subdirectory

### DIFF
--- a/.github/workflows/bizdev-eval.yml
+++ b/.github/workflows/bizdev-eval.yml
@@ -23,4 +23,4 @@ jobs:
 
       - name: Run BizDev eval harness
         run: |
-          pytest tests/bizdev -q
+          cd tests/bizdev && pytest -q --no-header --tb=short


### PR DESCRIPTION
## Summary
- Change to tests/bizdev directory before running pytest
- Prevents loading of root conftest.py that requires asyncpg
- Resolves persistent 'asyncpg not available' errors in CI

## Root Cause
Even with an empty conftest.py in tests/bizdev, pytest was still loading the parent conftest.py when run from the project root.

## Solution
Run pytest from within the tests/bizdev directory to ensure complete isolation from the root test configuration.

## Test Plan
- BizDev eval workflow will now execute tests successfully
- Tests run in complete isolation from root dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)