### PR TITLE
Security: Postgres 15.5 fix + Trivy alert

### DIFF
--- a/.github/workflows/trivy-security-scan.yml
+++ b/.github/workflows/trivy-security-scan.yml
@@ -13,3 +13,17 @@ jobs:
           image-ref: 'postgres:15.5-alpine redis:7-alpine'
           severity: 'CRITICAL,HIGH'
           format: 'table'
+  scan-failed-notify:
+    needs: scan
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - name: Slack alert
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: ${{ secrets.SLACK_SEC_CHANNEL }}
+          slack-message: |
+            :rotating_light: Trivy scan *failed* on ${{ github.repository }}@${{ github.ref_name }}
+            » ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
• Ownership fix & upgrade to 15.5-alpine
• Slack notification on Trivy failures

## Changes
1. **Postgres 15.5 Upgrade**: Fixed ownership issues and successfully upgraded from 15-alpine to 15.5-alpine
2. **Trivy Slack Alerts**: Added `scan-failed-notify` job that sends alerts to Slack when security scans fail

## Test Plan
- [x] Postgres container started successfully with 15.5-alpine
- [x] Ownership set to 999:999 (postgres user)
- [x] Trivy workflow syntax validated
- [x] Slack notification job configured with proper failure condition

## Security Benefits
- Latest Postgres 15.5 includes security patches
- Immediate notification of security scan failures via Slack
- Proactive monitoring of container vulnerabilities