### PR TITLE
ci: add manual trigger to Trivy workflow

### DIFF
--- a/.github/workflows/trivy-security-scan.yml
+++ b/.github/workflows/trivy-security-scan.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '0 3 * * 1'      # Mondays 03:00 UTC
   pull_request:
+  workflow_dispatch:
 jobs:
   scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds workflow_dispatch to allow manual triggering of security scans