### PR TITLE
fix(ci): use matrix strategy for multiple images in Trivy scan

### DIFF
--- a/.github/workflows/trivy-security-scan.yml
+++ b/.github/workflows/trivy-security-scan.yml
@@ -7,11 +7,14 @@ on:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ['postgres:15.5-alpine', 'redis:7-alpine']
     steps:
       - uses: actions/checkout@v4
       - uses: aquasecurity/trivy-action@0.20.0
         with:
-          image-ref: 'postgres:15.5-alpine redis:7-alpine'
+          image-ref: ${{ matrix.image }}
           severity: 'CRITICAL,HIGH'
           format: 'table'
   scan-failed-notify:


### PR DESCRIPTION
Fixes the Trivy workflow to properly scan multiple images using matrix strategy. The previous approach of specifying multiple images in one command caused the scan to fail.