### PR TITLE
Core cold-start polish: port & probe fixes + CI smoke

### DIFF
--- a/.github/workflows/core-smoke.yml
+++ b/.github/workflows/core-smoke.yml
@@ -1,0 +1,25 @@
+name: core-coldstart-smoke
+on:
+  pull_request:
+    paths:
+      - cold-start-core.yml
+      - .github/workflows/core-smoke.yml
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: GHCR login
+        run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u locotoki --password-stdin
+      - name: Pull & start core profile
+        run: |
+          docker compose -f cold-start-core.yml pull
+          docker compose -f cold-start-core.yml up -d
+          sleep 25
+          unhealthy=$(docker compose ps --services --filter "status=running" \
+                       | xargs -I{} sh -c 'hs=$(docker inspect -f "{{.State.Health.Status}}" $(docker compose ps -q {} 2>/dev/null||true) 2>/dev/null||echo n/a); [ "$hs" = "unhealthy" ] && echo {}')
+          if [ -n "$unhealthy" ]; then
+            echo "Unhealthy containers: $unhealthy"; docker compose ps; exit 1; fi
+      - name: Teardown
+        if: always()
+        run: docker compose -f cold-start-core.yml down -v

--- a/cold-start-core.yml
+++ b/cold-start-core.yml
@@ -1,0 +1,190 @@
+services:
+  # PostgreSQL database
+  db-postgres:
+    image: postgres:15.5-alpine
+    container_name: db-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - alfred-network
+
+  # Redis cache
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - alfred-network
+
+  # Redis monitoring
+  monitoring-redis:
+    image: oliver006/redis_exporter:v1.55.0
+    container_name: monitoring-redis
+    ports:
+      - "9121:9121"
+    environment:
+      - REDIS_ADDR=redis://redis:6379
+    depends_on:
+      - redis
+    networks:
+      - alfred-network
+
+  # PubSub Emulator
+  pubsub-emulator:
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
+    container_name: pubsub-emulator
+    ports:
+      - "8085:8085"
+    command: gcloud beta emulators pubsub start --host-port=0.0.0.0:8085
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8085"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - alfred-network
+
+  # Agent Core service
+  agent-core:
+    image: ghcr.io/locotoki/agent-core:v0.9.6
+    container_name: agent-core
+    ports:
+      - "8011:8011"
+    environment:
+      - ALFRED_ENVIRONMENT=development
+      - ALFRED_DEBUG=true
+      - ALFRED_DATABASE_URL=postgresql://postgres:postgres@db-postgres:5432/postgres
+      - ALFRED_REDIS_URL=redis://redis:6379
+      - ALFRED_PUBSUB_EMULATOR_HOST=pubsub-emulator:8085
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8011/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    depends_on:
+      db-postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      pubsub-emulator:
+        condition: service_healthy
+    networks:
+      - alfred-network
+
+  # Bizdev Agent
+  agent-bizdev:
+    image: ghcr.io/locotoki/agent-bizdev:edge
+    container_name: agent-bizdev
+    ports:
+      - "8012:8012"
+    environment:
+      - ALFRED_ENVIRONMENT=development
+      - ALFRED_DEBUG=true
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8012/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - alfred-network
+
+  # HubSpot Mock
+  hubspot-mock:
+    image: ghcr.io/locotoki/hubspot-mock:latest
+    container_name: hubspot-mock
+    ports:
+      - "8095:8095"
+    environment:
+      - PORT=8095
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8095/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - alfred-network
+
+  # Prometheus
+  monitoring-db:
+    image: prom/prometheus:v2.48.0
+    container_name: monitoring-db
+    ports:
+      - "9090:9090"
+    volumes:
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - alfred-network
+
+  # Grafana
+  monitoring-dashboard:
+    image: grafana/grafana:10.2.2
+    container_name: monitoring-dashboard
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - monitoring-db
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - alfred-network
+
+  # Vector DB (Qdrant)
+  vector-db:
+    image: qdrant/qdrant:v1.7.4
+    container_name: vector-db
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    environment:
+      - QDRANT__SERVICE__HTTP_PORT=6333
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:6333/readyz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - alfred-network
+
+networks:
+  alfred-network:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  prometheus_data:
+  grafana_data:
+  qdrant_data:

--- a/metrics/scripts_inventory.csv
+++ b/metrics/scripts_inventory.csv
@@ -126,6 +126,7 @@ bootstrap/init-storage-schema.sh,.sh,446,UNKNOWN
 build-push-all.sh,.sh,3807,UNKNOWN
 build-push-start.sh,.sh,1859,UNKNOWN
 clean-youtube-service.ts,.ts,16421,UNKNOWN
+core-polish-pack.sh,.sh,3010,UNKNOWN
 create-niche-scout-results.js,.js,2574,UNKNOWN
 diagnostics/rca/app.py,.py,5832,UNKNOWN
 diagnostics/rca/fix_app.py,.py,6833,UNKNOWN
@@ -613,6 +614,7 @@ simplified-youtube-service.ts,.ts,16413,UNKNOWN
 skip_ci_sc320.sh,.sh,653,UNKNOWN
 slack-bot/src/app.py,.py,1087,UNKNOWN
 start-all-services.sh,.sh,1499,UNKNOWN
+start-core-services.sh,.sh,1140,UNKNOWN
 start-platform-dryrun.sh,.sh,5795,UNKNOWN
 start-platform.sh,.sh,3962,UNKNOWN
 start-slack-commands.sh,.sh,1640,UNKNOWN


### PR DESCRIPTION
### Changes
* HubSpot-mock port set to **8095:8095**
* Added wget-based health-probe for vector-db (using /readyz endpoint)
* Introduced **core-coldstart-smoke** workflow.

Merge after CI green; makes cold-start fully hands-off.