### PR TITLE
docs(ADR-013): define CRM sync contract; add OpenAPI & event schema stubs

### DIFF
--- a/docs/adr/013-crm-sync-contract.md
+++ b/docs/adr/013-crm-sync-contract.md
@@ -1,0 +1,16 @@
+# ADR-013: CRM Sync Contract
+
+## Status
+Proposed – 28 May 2025
+
+## Context
+The BizDev MVP requires a deterministic contract between *agent-bizdev*
+and the HubSpot-mock service to ensure idempotent lead synchronisation.
+
+## Decision
+We will expose ...
+
+<!-- TODO: fill out tables for endpoint schema, retry semantics, id mapping -->
+
+## Consequences
+* All downstream services must ...

--- a/docs/schemas/contact_sync_event.json
+++ b/docs/schemas/contact_sync_event.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ContactSyncEvent",
+  "type": "object",
+  "required": ["email", "source", "timestamp"],
+  "properties": {
+    "email": { "type": "string", "format": "email" },
+    "source": { "type": "string", "enum": ["web", "pdf", "manual"] },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "payload": { "type": "object" }
+  }
+}

--- a/services/hubspot-mock/openapi.yaml
+++ b/services/hubspot-mock/openapi.yaml
@@ -1,0 +1,26 @@
+openapi: "3.1.0"
+info:
+  title: HubSpot Mock API
+  version: "0.1.0"
+paths:
+  /contacts:
+    post:
+      summary: Create or update contact
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Contact'
+      responses:
+        "200":
+          description: Contact upserted
+components:
+  schemas:
+    Contact:
+      type: object
+      required: [email]
+      properties:
+        email: {type: string, format: email}
+        firstName: {type: string}
+        lastName: {type: string}

--- a/services/hubspot-mock/openapi.yaml
+++ b/services/hubspot-mock/openapi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 openapi: "3.1.0"
 info:
   title: HubSpot Mock API


### PR DESCRIPTION
## ✅ Execution Summary
Wave 1 - Contract Definition for BizDev MVP CRM Sync

## 🧾 Changes
- Created ADR-013 skeleton for CRM sync contract
- Added OpenAPI 3.1 spec for hubspot-mock service
- Added JSON schema for ContactSyncEvent

## 📍 Next Required Action
Team review of contract definitions before implementation begins

## TODO
- Fill out endpoint schema tables in ADR
- Define retry semantics
- Specify id mapping strategy