### PR TITLE
fix(ci): use GHCR_PAT for release workflow

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
       - run: |
           TAG=${GITHUB_REF_NAME}
           for svc in crm-sync contact-ingest hubspot-mock; do


### PR DESCRIPTION
## Summary
Updates the release-images workflow to use GHCR_PAT instead of GITHUB_TOKEN for pushing images to GitHub Container Registry.

## Why
The default GITHUB_TOKEN lacks write:packages permission, causing the workflow to fail with:
\\\

## Solution
Use a Personal Access Token (PAT) with write:packages permission that needs to be added as a repository secret.

## Next Steps
1. Add GHCR_PAT to repository secrets (see GHCR-PAT-SETUP-GUIDE.md)
2. Make the 3 packages public in GitHub UI
3. Delete and recreate the v0.9.11-beta tag to trigger the workflow