### PR TITLE
feat(monitoring): add ContactIngestRateZero Prometheus alert

### DIFF
--- a/charts/alerts/contact-ingest.yaml
+++ b/charts/alerts/contact-ingest.yaml
@@ -1,0 +1,15 @@
+# charts/alerts/contact-ingest.yaml
+groups:
+- name: contact-ingest
+  rules:
+  - alert: ContactIngestRateZero
+    expr: rate(contact_ingest_total[5m]) == 0
+    for: 10m
+    labels:
+      severity: warning
+      service: contact_ingest
+    annotations:
+      summary: "Contact ingest rate has been zero for 10 m"
+      description: |
+        No contacts ingested in the last 10 minutes.
+        Check contact-ingest service and upstream source.


### PR DESCRIPTION
## Summary
- Added Prometheus alert for contact-ingest service
- Alert triggers when ingest rate is zero for 10 minutes
- Part of post-beta hardening tasks

## Changes
- Created charts/alerts/contact-ingest.yaml with ContactIngestRateZero alert rule

## Testing
- Alert follows same pattern as other service alerts
- Will auto-reload in Prometheus configuration