### PR TITLE
CI: auto-publish Docker images on tag

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,36 @@
+name: Build & Publish Docker images (tag)
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        svc: [alfred-core, alfred-bot, agent_bizops, contact-ingest, crm-sync, slack_app, social-intel, db-metrics]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push ${{ matrix.svc }}
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}/${{ matrix.svc }}:${{ github.ref_name }}
+          file: services/${{ matrix.svc }}/Dockerfile
+          context: services/${{ matrix.svc }}


### PR DESCRIPTION
Ensures future tags are runnable.

## Changes
- Add GitHub Actions workflow to automatically build and push Docker images when a tag is created
- Builds images for core services: alfred-core, alfred-bot, agent_bizops, contact-ingest, crm-sync, slack_app, social-intel, db-metrics
- Pushes to GitHub Container Registry (ghcr.io)

## Benefits
- Automated release process - no manual image builds needed
- All tagged releases will have corresponding Docker images
- Enables smoke testing of any tagged version