### PR TITLE
Bench burn-rate alert & panel

### DIFF
--- a/grafana/dashboards/bench-burnrate.json
+++ b/grafana/dashboards/bench-burnrate.json
@@ -1,0 +1,236 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.075
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "mean"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"bench\"}[5m])) by (le))",
+          "refId": "A",
+          "legendFormat": "p95 latency"
+        },
+        {
+          "expr": "0.075",
+          "refId": "B",
+          "legendFormat": "SLA (75ms)"
+        }
+      ],
+      "title": "Bench P95 Latency vs SLA",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "(histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"bench\"}[5m])) by (le))) / 0.075",
+          "refId": "A"
+        }
+      ],
+      "title": "Burn Rate (p95/SLA)",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "ALERTS{alertname=\"BenchLatencyBurnRate\",alertstate=\"firing\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Burn Rate Alerts",
+      "type": "stat"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": ["bench", "performance", "sla"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Bench Burn Rate Dashboard",
+  "uid": "bench-burnrate",
+  "version": 0
+}

--- a/k8s/bench-burnrate-rule.yaml
+++ b/k8s/bench-burnrate-rule.yaml
@@ -1,0 +1,42 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: bench-burnrate
+  namespace: observability
+spec:
+  groups:
+    - name: bench.rules
+      interval: 30s
+      rules:
+        - alert: BenchLatencyBurnRate
+          expr: |
+            (
+              histogram_quantile(0.95,
+                sum(rate(http_request_duration_seconds_bucket{job="bench"}[5m])) by (le)
+              )
+            ) > 0.075
+          for: 10m
+          labels:
+            severity: page
+            component: bench
+            team: platform
+          annotations:
+            summary: "Bench p95 latency burn-rate high"
+            description: "Bench p95 latency {{ $value }}s is breaching the 75ms SLA for 10 min."
+            runbook_url: "https://docs.alfred.platform/runbooks/bench-latency"
+
+        - alert: BenchLatencySLABreach
+          expr: |
+            (
+              histogram_quantile(0.95,
+                sum(rate(http_request_duration_seconds_bucket{job="bench"}[1m])) by (le)
+              )
+            ) > 0.075
+          for: 2m
+          labels:
+            severity: warning
+            component: bench
+            team: platform
+          annotations:
+            summary: "Bench p95 latency SLA breach"
+            description: "Bench p95 latency {{ $value }}s exceeded 75ms SLA for 2 minutes."


### PR DESCRIPTION
feat(bench): add burn-rate monitoring

- Add PrometheusRule for BenchLatencyBurnRate alert (75ms SLA)
- Add Grafana dashboard for burn rate visualization
- Tracks P95 latency against SLA threshold
- 10min window for alert stability

Part of bench performance monitoring improvements.