### PR TITLE
Hot-fix: docker-release build context

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -33,4 +33,4 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}/${{ matrix.svc }}:${{ github.ref_name }}
           file: services/${{ matrix.svc }}/Dockerfile
-          context: services/${{ matrix.svc }}
+          context: .


### PR DESCRIPTION
Build from repo root to include /health.json and /libs; base image now published.

## Problem
Docker builds were failing with:
- ERROR: failed to solve: ghcr.io/alfred/healthcheck:0.4.0: not found  
- ERROR: failed to compute cache key: \/health.json\: not found
- ERROR: failed to compute cache key: \/libs\: not found

## Solution
- Change Docker build context from  to  (repo root)
- This allows Dockerfiles to COPY from shared locations like /libs and /health.json
- Base healthcheck image has been published to ghcr.io

## Testing
Will re-run the v0.9.17-beta tag workflow after merge.