### PR TITLE
Align healthcheck base-image prefix

### DIFF
--- a/.github/workflows/services/db-api/Dockerfile.new
+++ b/.github/workflows/services/db-api/Dockerfile.new
@@ -1,4 +1,4 @@
-FROM alfred/healthcheck:0.4.0 AS healthcheck
+FROM ghcr.io/locotoki/alfred-agent-platform-v2/healthcheck:0.4.0 AS healthcheck
 
 FROM postgres:14
 

--- a/alfred/ui/Dockerfile
+++ b/alfred/ui/Dockerfile
@@ -1,3 +1,5 @@
+FROM ghcr.io/locotoki/alfred-agent-platform-v2/healthcheck:0.4.0 AS healthcheck
+
 FROM python:3.11-slim
 
 WORKDIR /app

--- a/rag-gateway/Dockerfile.new
+++ b/rag-gateway/Dockerfile.new
@@ -1,4 +1,4 @@
-FROM ghcr.io/alfred/healthcheck:0.4.0 AS healthcheck
+FROM ghcr.io/locotoki/alfred-agent-platform-v2/healthcheck:0.4.0 AS healthcheck
 
 FROM python:3.11-slim
 

--- a/services/db-metrics/Dockerfile
+++ b/services/db-metrics/Dockerfile
@@ -1,3 +1,5 @@
+FROM ghcr.io/locotoki/alfred-agent-platform-v2/healthcheck:0.4.0 AS healthcheck
+
 FROM python:3.11-slim
 
 WORKDIR /app

--- a/services/pubsub/Dockerfile
+++ b/services/pubsub/Dockerfile
@@ -1,3 +1,5 @@
+FROM ghcr.io/locotoki/alfred-agent-platform-v2/healthcheck:0.4.0 AS healthcheck
+
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:latest
 
 

--- a/services/social-intel/Dockerfile
+++ b/services/social-intel/Dockerfile
@@ -1,3 +1,5 @@
+FROM ghcr.io/locotoki/alfred-agent-platform-v2/healthcheck:0.4.0 AS healthcheck
+
 FROM python:3.11-slim
 
 WORKDIR /app


### PR DESCRIPTION
All services now pull ghcr.io/locotoki/alfred-agent-platform-v2/healthcheck:0.4.0

This PR standardizes all healthcheck base image references to use the canonical prefix, fixing registry drift issues in the docker-release workflow.