### PR TITLE
Use GHCR_PAT for docker registry authentication

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Determine tag
         id: tag


### PR DESCRIPTION
This PR updates the docker-release workflow to use GHCR_PAT instead of GITHUB_TOKEN for authenticating with ghcr.io.

This enables pushing images to the GitHub Container Registry when the default GITHUB_TOKEN lacks sufficient permissions.

**Requirements:**
- GHCR_PAT secret must be configured in repository settings with write:packages scope