### PR TITLE
fix(alfred-core): remove leading slash from ASSETS path

### DIFF
--- a/services/alfred-core/Dockerfile
+++ b/services/alfred-core/Dockerfile
@@ -1,4 +1,4 @@
-ARG ASSETS=/assets
+ARG ASSETS=assets
 FROM python:3.11-slim
 
 # Make ASSETS available as environment variable


### PR DESCRIPTION
## Summary
Fixes docker-release workflow failure for alfred-core image build.

## Problem
The ASSETS ARG had a default value of \ which caused a double slash in the COPY command:
\\\

## Solution
Changed \ to \ to prevent the double slash.

## Test
This will fix the build error in docker-release workflow:
\\\

Closes the build failure seen in workflow run 15239120587