### PR TITLE
feat(alfred-core): add missing health.json asset file

### DIFF
--- a/services/alfred-core/assets/health.json
+++ b/services/alfred-core/assets/health.json
@@ -1,0 +1,1 @@
+{ "status": "ok", "ts": "placeholder" }


### PR DESCRIPTION
## Summary
Adds the missing health.json file that was causing docker-release workflow to fail.

## Problem
The alfred-core Dockerfile references this file:
`COPY services/alfred-core/${ASSETS}/health.json /app/health.json`

But the file was not tracked in git, causing the build to fail with:
`ERROR: failed to solve: failed to compute cache key: "/services/alfred-core/assets/health.json": not found`

## Solution
Add the health.json file to git so it's available during docker builds.

This completes the fix for the alfred-core build issue.