### PR TITLE
fix: remove GHCR_PAT reference to restore CI Pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
       - name: Push ${{ matrix.service }} image to GHCR
-        if: ${{ secrets.GHCR_PAT != '' }}
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v4
         with:
           context: ./services/${{ matrix.service }}


### PR DESCRIPTION
Fixes the CI Pipeline startup_failure by removing the reference to non-existent GHCR_PAT secret.

The workflow was checking for `secrets.GHCR_PAT` which doesn't exist in the repository settings, causing GitHub Actions to fail at startup.

Changed the condition to only push images on main branch pushes, which is the standard pattern.